### PR TITLE
feat: add kubectl microvm image commands with --wait support

### DIFF
--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageCommand.java
@@ -1,0 +1,15 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import picocli.CommandLine.Command;
+
+@Command(name = "image", description = "Manage MicroVM images",
+    subcommands = {
+        ImageCreateCommand.class,
+        ImageListCommand.class,
+        ImageDescribeCommand.class,
+        ImageUpdateCommand.class,
+        ImageDeleteCommand.class
+    },
+    mixinStandardHelpOptions = true)
+public class ImageCommand {
+}

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageCreateCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageCreateCommand.java
@@ -31,6 +31,12 @@ public class ImageCreateCommand implements Runnable {
     @Option(names = {"--auto-activate"}, defaultValue = "true", description = "Auto-activate on successful build (default: true)")
     boolean autoActivate;
 
+    @Option(names = {"--wait"}, description = "Wait for build to complete and print state transitions")
+    boolean wait;
+
+    @Option(names = {"--wait-timeout"}, defaultValue = "600", description = "Wait timeout in seconds (default: 600)")
+    int waitTimeout;
+
     @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
     String namespace;
 
@@ -58,6 +64,11 @@ public class ImageCreateCommand implements Runnable {
 
             client.resource(image).inNamespace(namespace).create();
             System.out.printf("microvm-image/%s created (source: s3://%s/%s)%n", name, s3Bucket, s3Key);
+
+            if (wait) {
+                boolean success = new ImageWaiter(client, name, namespace, waitTimeout).waitForBuild();
+                if (!success) System.exit(1);
+            }
         } catch (KubernetesClientException e) {
             System.err.println("Error creating MicroVMImage: " + e.getMessage());
             System.exit(1);

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageCreateCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageCreateCommand.java
@@ -1,0 +1,66 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImage;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageSpec;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageSource;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "create", description = "Create a new MicroVM image from S3 source", mixinStandardHelpOptions = true)
+public class ImageCreateCommand implements Runnable {
+
+    @Option(names = {"--name"}, required = true, description = "Name of the MicroVMImage")
+    String name;
+
+    @Option(names = {"--s3-bucket"}, required = true, description = "S3 bucket containing source zip")
+    String s3Bucket;
+
+    @Option(names = {"--s3-key"}, required = true, description = "S3 key of the source zip (Dockerfile + app code)")
+    String s3Key;
+
+    @Option(names = {"--base-image"}, description = "Base image ARN")
+    String baseImageArn;
+
+    @Option(names = {"--build-timeout"}, defaultValue = "600", description = "Build timeout in seconds (default: 600)")
+    int buildTimeout;
+
+    @Option(names = {"--auto-activate"}, defaultValue = "true", description = "Auto-activate on successful build (default: true)")
+    boolean autoActivate;
+
+    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
+    String namespace;
+
+    @Inject
+    KubernetesClient client;
+
+    @Override
+    public void run() {
+        try {
+            MicroVMImage image = new MicroVMImage();
+            image.setMetadata(new ObjectMetaBuilder()
+                .withName(name)
+                .withNamespace(namespace)
+                .build());
+
+            MicroVMImageSpec spec = new MicroVMImageSpec();
+            MicroVMImageSource source = new MicroVMImageSource();
+            source.setS3Bucket(s3Bucket);
+            source.setS3Key(s3Key);
+            spec.setSource(source);
+            spec.setBaseImageArn(baseImageArn);
+            spec.setBuildTimeoutSeconds(buildTimeout);
+            spec.setAutoActivate(autoActivate);
+            image.setSpec(spec);
+
+            client.resource(image).inNamespace(namespace).create();
+            System.out.printf("microvm-image/%s created (source: s3://%s/%s)%n", name, s3Bucket, s3Key);
+        } catch (KubernetesClientException e) {
+            System.err.println("Error creating MicroVMImage: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageDeleteCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageDeleteCommand.java
@@ -1,0 +1,41 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImage;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "delete", description = "Delete a MicroVM image", mixinStandardHelpOptions = true)
+public class ImageDeleteCommand implements Runnable {
+
+    @Option(names = {"--name"}, required = true, description = "Name of the MicroVMImage to delete")
+    String name;
+
+    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
+    String namespace;
+
+    @Inject
+    KubernetesClient client;
+
+    @Override
+    public void run() {
+        try {
+            MicroVMImage image = client.resources(MicroVMImage.class)
+                .inNamespace(namespace).withName(name).get();
+
+            if (image == null) {
+                System.err.printf("MicroVMImage '%s' not found in namespace '%s'%n", name, namespace);
+                System.exit(1);
+                return;
+            }
+
+            client.resource(image).delete();
+            System.out.printf("microvm-image/%s deleted%n", name);
+        } catch (KubernetesClientException e) {
+            System.err.println("Error deleting MicroVMImage: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageDescribeCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageDescribeCommand.java
@@ -1,0 +1,73 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImage;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageStatus;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageVersionInfo;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "describe", description = "Show details of a MicroVM image", mixinStandardHelpOptions = true)
+public class ImageDescribeCommand implements Runnable {
+
+    @Option(names = {"--name"}, required = true, description = "Name of the MicroVMImage")
+    String name;
+
+    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
+    String namespace;
+
+    @Inject
+    KubernetesClient client;
+
+    @Override
+    public void run() {
+        MicroVMImage image = client.resources(MicroVMImage.class)
+            .inNamespace(namespace).withName(name).get();
+
+        if (image == null) {
+            System.err.printf("MicroVMImage '%s' not found in namespace '%s'%n", name, namespace);
+            System.exit(1);
+            return;
+        }
+
+        System.out.printf("Name:           %s%n", image.getMetadata().getName());
+        System.out.printf("Namespace:      %s%n", image.getMetadata().getNamespace());
+
+        if (image.getSpec().getSource() != null) {
+            System.out.printf("Source:         s3://%s/%s%n",
+                image.getSpec().getSource().getS3Bucket(), image.getSpec().getSource().getS3Key());
+        }
+        if (image.getSpec().getBaseImageArn() != null) {
+            System.out.printf("Base Image:     %s%n", image.getSpec().getBaseImageArn());
+        }
+        System.out.printf("Build Timeout:  %ds%n",
+            image.getSpec().getBuildTimeoutSeconds() != null ? image.getSpec().getBuildTimeoutSeconds() : 600);
+        System.out.printf("Auto-Activate:  %s%n",
+            image.getSpec().getAutoActivate() != null ? image.getSpec().getAutoActivate() : true);
+
+        MicroVMImageStatus status = image.getStatus();
+        if (status != null) {
+            System.out.println();
+            if (status.getImageArn() != null) System.out.printf("Image ARN:      %s%n", status.getImageArn());
+            System.out.printf("Active Version: %s%n", status.getActiveVersion() != null ? status.getActiveVersion() : "-");
+            System.out.printf("Latest Version: %s%n", status.getLatestVersion() != null ? status.getLatestVersion() : "-");
+
+            if (status.getVersions() != null && !status.getVersions().isEmpty()) {
+                System.out.println();
+                System.out.println("Versions:");
+                System.out.printf("  %-8s %-14s %-25s %-25s%n", "VER", "STATE", "STARTED", "BUILT");
+                for (MicroVMImageVersionInfo v : status.getVersions()) {
+                    System.out.printf("  %-8s %-14s %-25s %-25s%n",
+                        v.getVersion(),
+                        v.getState() != null ? v.getState() : "-",
+                        v.getStartedAt() != null ? v.getStartedAt() : "-",
+                        v.getBuiltAt() != null ? v.getBuiltAt() : "-");
+                    if (v.getFailureReason() != null) {
+                        System.out.printf("           Reason: %s%n", v.getFailureReason());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageListCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageListCommand.java
@@ -1,0 +1,59 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImage;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageStatus;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageVersionInfo;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.util.List;
+
+@Command(name = "list", description = "List MicroVM images", mixinStandardHelpOptions = true)
+public class ImageListCommand implements Runnable {
+
+    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
+    String namespace;
+
+    @Option(names = {"-A", "--all-namespaces"}, description = "List across all namespaces")
+    boolean allNamespaces;
+
+    @Inject
+    KubernetesClient client;
+
+    @Override
+    public void run() {
+        List<MicroVMImage> images;
+        if (allNamespaces) {
+            images = client.resources(MicroVMImage.class).inAnyNamespace().list().getItems();
+        } else {
+            images = client.resources(MicroVMImage.class).inNamespace(namespace).list().getItems();
+        }
+
+        if (images.isEmpty()) {
+            System.out.println("No MicroVM images found.");
+            return;
+        }
+
+        System.out.printf("%-20s %-12s %-10s %-40s %-8s%n", "NAME", "ACTIVE-VER", "LATEST-VER", "SOURCE", "STATE");
+        for (MicroVMImage img : images) {
+            MicroVMImageStatus status = img.getStatus();
+            String activeVer = status != null && status.getActiveVersion() != null ? String.valueOf(status.getActiveVersion()) : "-";
+            String latestVer = status != null && status.getLatestVersion() != null ? String.valueOf(status.getLatestVersion()) : "-";
+            String source = img.getSpec() != null && img.getSpec().getSource() != null
+                ? "s3://" + img.getSpec().getSource().getS3Bucket() + "/" + img.getSpec().getSource().getS3Key()
+                : "-";
+            if (source.length() > 40) source = source.substring(0, 39) + "…";
+            String state = getLatestState(status);
+            System.out.printf("%-20s %-12s %-10s %-40s %-8s%n", img.getMetadata().getName(), activeVer, latestVer, source, state);
+        }
+    }
+
+    private String getLatestState(MicroVMImageStatus status) {
+        if (status == null || status.getVersions() == null || status.getVersions().isEmpty()) return "-";
+        MicroVMImageVersionInfo latest = status.getVersions().getFirst();
+        return latest.getState() != null ? latest.getState() : "-";
+    }
+}

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageUpdateCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageUpdateCommand.java
@@ -21,6 +21,12 @@ public class ImageUpdateCommand implements Runnable {
     @Option(names = {"--s3-bucket"}, description = "S3 bucket (if changing)")
     String s3Bucket;
 
+    @Option(names = {"--wait"}, description = "Wait for build to complete and print state transitions")
+    boolean wait;
+
+    @Option(names = {"--wait-timeout"}, defaultValue = "600", description = "Wait timeout in seconds (default: 600)")
+    int waitTimeout;
+
     @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
     String namespace;
 
@@ -46,6 +52,11 @@ public class ImageUpdateCommand implements Runnable {
             client.resource(image).inNamespace(namespace).update();
             System.out.printf("microvm-image/%s updated (new source: s3://%s/%s) — build will start%n",
                 name, source.getS3Bucket(), s3Key);
+
+            if (wait) {
+                boolean success = new ImageWaiter(client, name, namespace, waitTimeout).waitForBuild();
+                if (!success) System.exit(1);
+            }
         } catch (KubernetesClientException e) {
             System.err.println("Error updating MicroVMImage: " + e.getMessage());
             System.exit(1);

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageUpdateCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageUpdateCommand.java
@@ -1,0 +1,54 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImage;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageSource;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageSpec;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(name = "update", description = "Update a MicroVM image with new source (triggers rebuild)", mixinStandardHelpOptions = true)
+public class ImageUpdateCommand implements Runnable {
+
+    @Option(names = {"--name"}, required = true, description = "Name of the MicroVMImage to update")
+    String name;
+
+    @Option(names = {"--s3-key"}, required = true, description = "New S3 key for the updated source zip")
+    String s3Key;
+
+    @Option(names = {"--s3-bucket"}, description = "S3 bucket (if changing)")
+    String s3Bucket;
+
+    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
+    String namespace;
+
+    @Inject
+    KubernetesClient client;
+
+    @Override
+    public void run() {
+        try {
+            MicroVMImage image = client.resources(MicroVMImage.class)
+                .inNamespace(namespace).withName(name).get();
+
+            if (image == null) {
+                System.err.printf("MicroVMImage '%s' not found in namespace '%s'%n", name, namespace);
+                System.exit(1);
+                return;
+            }
+
+            MicroVMImageSource source = image.getSpec().getSource();
+            if (s3Bucket != null) source.setS3Bucket(s3Bucket);
+            source.setS3Key(s3Key);
+
+            client.resource(image).inNamespace(namespace).update();
+            System.out.printf("microvm-image/%s updated (new source: s3://%s/%s) — build will start%n",
+                name, source.getS3Bucket(), s3Key);
+        } catch (KubernetesClientException e) {
+            System.err.println("Error updating MicroVMImage: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageWaiter.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageWaiter.java
@@ -1,0 +1,103 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImage;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageStatus;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImageVersionInfo;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.List;
+
+/**
+ * Polls a MicroVMImage until the latest version reaches a terminal state.
+ * Prints state transitions as they happen.
+ */
+public class ImageWaiter {
+
+    private static final long POLL_INTERVAL_MS = 2000;
+
+    private final KubernetesClient client;
+    private final String name;
+    private final String namespace;
+    private final int timeoutSeconds;
+
+    public ImageWaiter(KubernetesClient client, String name, String namespace, int timeoutSeconds) {
+        this.client = client;
+        this.name = name;
+        this.namespace = namespace;
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    /**
+     * Blocks until the latest image version reaches a terminal state or timeout.
+     * Returns true if successful, false if failed/timed out.
+     */
+    public boolean waitForBuild() {
+        long deadline = System.currentTimeMillis() + (timeoutSeconds * 1000L);
+        String lastState = null;
+
+        System.out.printf("⏳ Waiting for microvm-image/%s build (timeout: %ds)...%n", name, timeoutSeconds);
+
+        while (System.currentTimeMillis() < deadline) {
+            MicroVMImage image = client.resources(MicroVMImage.class)
+                .inNamespace(namespace).withName(name).get();
+
+            if (image == null) {
+                System.err.printf("❌ MicroVMImage '%s' not found%n", name);
+                return false;
+            }
+
+            MicroVMImageStatus status = image.getStatus();
+            if (status != null && status.getVersions() != null && !status.getVersions().isEmpty()) {
+                MicroVMImageVersionInfo latest = status.getVersions().getFirst();
+                String currentState = latest.getState();
+
+                if (currentState != null && !currentState.equals(lastState)) {
+                    printTransition(lastState, currentState, latest);
+                    lastState = currentState;
+                }
+
+                if (isTerminal(currentState)) {
+                    return isSuccess(currentState);
+                }
+            }
+
+            try {
+                Thread.sleep(POLL_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                System.err.println("Interrupted");
+                return false;
+            }
+        }
+
+        System.err.printf("❌ Timed out after %ds (last state: %s)%n", timeoutSeconds, lastState);
+        return false;
+    }
+
+    private void printTransition(String from, String to, MicroVMImageVersionInfo version) {
+        String arrow = from != null ? String.format("  %s → %s", from, to) : String.format("  → %s", to);
+        String detail = switch (to) {
+            case "Pending" -> "(queued for build)";
+            case "InProgress" -> "(building image from Dockerfile)";
+            case "Successful" -> String.format("(version %d ready)", version.getVersion());
+            case "Active" -> String.format("(version %d activated — serving traffic)", version.getVersion());
+            case "Failed" -> String.format("(build failed: %s)",
+                version.getFailureReason() != null ? version.getFailureReason() : "unknown");
+            default -> "";
+        };
+        System.out.printf("%s %s%n", arrow, detail);
+    }
+
+    private boolean isTerminal(String state) {
+        return state != null && List.of("Successful", "Active", "Failed").contains(state);
+    }
+
+    private boolean isSuccess(String state) {
+        if ("Failed".equals(state)) {
+            System.out.println("❌ Build failed.");
+            return false;
+        }
+        System.out.println("✅ Build completed successfully.");
+        return true;
+    }
+}

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/MicroVMCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/MicroVMCommand.java
@@ -24,7 +24,8 @@ import picocli.CommandLine.Command;
         StartCommand.class,
         LogsCommand.class,
         ExecCommand.class,
-        PoolCommand.class
+        PoolCommand.class,
+        ImageCommand.class
     }
 )
 public class MicroVMCommand {

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImage.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImage.java
@@ -1,0 +1,11 @@
+package ai.codriverlabs.microvm.operator.core.model;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("lambda.aws.amazon.com")
+@Version("v1alpha1")
+public class MicroVMImage extends CustomResource<MicroVMImageSpec, MicroVMImageStatus> implements Namespaced {
+}

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageSource.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageSource.java
@@ -1,0 +1,16 @@
+package ai.codriverlabs.microvm.operator.core.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MicroVMImageSource {
+
+    private String s3Bucket;
+    private String s3Key;
+
+    public String getS3Bucket() { return s3Bucket; }
+    public void setS3Bucket(String s3Bucket) { this.s3Bucket = s3Bucket; }
+
+    public String getS3Key() { return s3Key; }
+    public void setS3Key(String s3Key) { this.s3Key = s3Key; }
+}

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageSpec.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageSpec.java
@@ -1,0 +1,24 @@
+package ai.codriverlabs.microvm.operator.core.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MicroVMImageSpec {
+
+    private MicroVMImageSource source;
+    private String baseImageArn;
+    private Integer buildTimeoutSeconds;
+    private Boolean autoActivate;
+
+    public MicroVMImageSource getSource() { return source; }
+    public void setSource(MicroVMImageSource source) { this.source = source; }
+
+    public String getBaseImageArn() { return baseImageArn; }
+    public void setBaseImageArn(String baseImageArn) { this.baseImageArn = baseImageArn; }
+
+    public Integer getBuildTimeoutSeconds() { return buildTimeoutSeconds; }
+    public void setBuildTimeoutSeconds(Integer buildTimeoutSeconds) { this.buildTimeoutSeconds = buildTimeoutSeconds; }
+
+    public Boolean getAutoActivate() { return autoActivate; }
+    public void setAutoActivate(Boolean autoActivate) { this.autoActivate = autoActivate; }
+}

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageStatus.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageStatus.java
@@ -1,0 +1,26 @@
+package ai.codriverlabs.microvm.operator.core.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MicroVMImageStatus {
+
+    private String imageArn;
+    private Integer latestVersion;
+    private Integer activeVersion;
+    private List<MicroVMImageVersionInfo> versions;
+
+    public String getImageArn() { return imageArn; }
+    public void setImageArn(String imageArn) { this.imageArn = imageArn; }
+
+    public Integer getLatestVersion() { return latestVersion; }
+    public void setLatestVersion(Integer latestVersion) { this.latestVersion = latestVersion; }
+
+    public Integer getActiveVersion() { return activeVersion; }
+    public void setActiveVersion(Integer activeVersion) { this.activeVersion = activeVersion; }
+
+    public List<MicroVMImageVersionInfo> getVersions() { return versions; }
+    public void setVersions(List<MicroVMImageVersionInfo> versions) { this.versions = versions; }
+}

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageVersionInfo.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageVersionInfo.java
@@ -1,0 +1,28 @@
+package ai.codriverlabs.microvm.operator.core.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MicroVMImageVersionInfo {
+
+    private Integer version;
+    private String state;
+    private String builtAt;
+    private String startedAt;
+    private String failureReason;
+
+    public Integer getVersion() { return version; }
+    public void setVersion(Integer version) { this.version = version; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getBuiltAt() { return builtAt; }
+    public void setBuiltAt(String builtAt) { this.builtAt = builtAt; }
+
+    public String getStartedAt() { return startedAt; }
+    public void setStartedAt(String startedAt) { this.startedAt = startedAt; }
+
+    public String getFailureReason() { return failureReason; }
+    public void setFailureReason(String failureReason) { this.failureReason = failureReason; }
+}

--- a/operator-core/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
+++ b/operator-core/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
@@ -1,11 +1,15 @@
+ai/codriverlabs/microvm/operator/core/model/MicroVMImageVersionInfo.class
 ai/codriverlabs/microvm/operator/core/state/StateTransitionResult.class
+ai/codriverlabs/microvm/operator/core/model/MicroVMImage.class
 ai/codriverlabs/microvm/operator/core/model/Condition.class
+ai/codriverlabs/microvm/operator/core/model/MicroVMImageStatus.class
 ai/codriverlabs/microvm/operator/core/model/MicroVMSpec.class
 ai/codriverlabs/microvm/operator/core/state/MicroVMStateMachine.class
 ai/codriverlabs/microvm/operator/core/enums/MicroVMState.class
 ai/codriverlabs/microvm/operator/core/enums/DesiredState.class
 ai/codriverlabs/microvm/operator/core/model/MicroVM.class
 ai/codriverlabs/microvm/operator/core/model/MicroVMPool.class
+ai/codriverlabs/microvm/operator/core/model/MicroVMImageSource.class
 ai/codriverlabs/microvm/operator/core/model/MicroVMNetwork.class
 ai/codriverlabs/microvm/operator/core/model/MicroVMPoolSpec.class
 ai/codriverlabs/microvm/operator/core/state/StateTransitionResult$Invalid.class
@@ -13,5 +17,6 @@ ai/codriverlabs/microvm/operator/core/model/MicroVMPoolStatus.class
 ai/codriverlabs/microvm/operator/core/state/StateTransitionResult$Valid.class
 ai/codriverlabs/microvm/operator/core/model/MicroVMNetworkSpec.class
 ai/codriverlabs/microvm/operator/core/model/MicroVMTemplateSpec.class
+ai/codriverlabs/microvm/operator/core/model/MicroVMImageSpec.class
 ai/codriverlabs/microvm/operator/core/model/MicroVMStatus.class
 ai/codriverlabs/microvm/operator/core/model/MicroVMTemplate.class

--- a/operator-core/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/operator-core/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -2,6 +2,11 @@
 /home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/enums/MicroVMState.java
 /home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/Condition.java
 /home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVM.java
+/home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImage.java
+/home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageSource.java
+/home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageSpec.java
+/home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageStatus.java
+/home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageVersionInfo.java
 /home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMNetwork.java
 /home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMNetworkSpec.java
 /home/ubuntu/projects/pl-cloud/KubeMicroVM/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMPool.java


### PR DESCRIPTION
## Summary

Adds full `kubectl microvm image` subcommand group for the `MicroVMImage` lifecycle.

## Changes

### New CLI commands
- `kubectl microvm image create --name <name> --s3-bucket <bucket> --s3-key <key> [--wait]`
- `kubectl microvm image list [-A]`
- `kubectl microvm image describe --name <name>`
- `kubectl microvm image update --name <name> --s3-key <new-key> [--wait]`
- `kubectl microvm image delete --name <name>`

### `--wait` flag (create / update)
Streams live state transitions until the image reaches `Active` or fails:
```
→ Pending (queued for build)
Pending → InProgress (building image from Dockerfile)
InProgress → Successful (version 3 ready)
Successful → Active (version 3 activated — serving traffic)
✅ Build completed successfully.
```

### New CRD model classes (operator-core)
`MicroVMImage`, `MicroVMImageSpec`, `MicroVMImageSource`, `MicroVMImageStatus`, `MicroVMImageVersionInfo`