### PR TITLE
feat: MicroVMClass — named runtime profiles (StorageClass pattern)

### DIFF
--- a/charts/lambda-vm-ack-operator/crds/microvmclasses.lambda.aws.amazon.com.yaml
+++ b/charts/lambda-vm-ack-operator/crds/microvmclasses.lambda.aws.amazon.com.yaml
@@ -1,0 +1,72 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: microvmclasses.lambda.aws.amazon.com
+spec:
+  group: lambda.aws.amazon.com
+  names:
+    kind: MicroVMClass
+    listKind: MicroVMClassList
+    plural: microvmclasses
+    singular: microvmclass
+    shortNames:
+      - mvmclass
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: MaxIdle
+          type: integer
+          jsonPath: .spec.maxIdleDurationSeconds
+        - name: AutoResume
+          type: boolean
+          jsonPath: .spec.autoResumeEnabled
+        - name: Description
+          type: string
+          jsonPath: .spec.description
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              description: >
+                Runtime profile applied to MicroVMs that reference this class via spec.className.
+                All fields are optional. Fields explicitly set on the MicroVM take precedence.
+              properties:
+                maxIdleDurationSeconds:
+                  type: integer
+                  minimum: 1
+                  maximum: 28800
+                  description: Seconds without traffic before Lambda auto-suspends the MicroVM.
+                suspendedDurationSeconds:
+                  type: integer
+                  minimum: 1
+                  maximum: 28800
+                  description: Seconds in SUSPENDED state before Lambda auto-terminates.
+                autoResumeEnabled:
+                  type: boolean
+                  description: When true, suspended MicroVM resumes automatically when traffic arrives.
+                maximumDurationSeconds:
+                  type: integer
+                  minimum: 1
+                  maximum: 28800
+                  description: Hard cap on total MicroVM lifetime (running + suspended).
+                ingressNetworkConnectors:
+                  type: array
+                  items:
+                    type: string
+                  description: Inbound connector ARNs (e.g. ALL_INGRESS).
+                egressNetworkConnectors:
+                  type: array
+                  items:
+                    type: string
+                  description: Outbound connector ARNs (e.g. INTERNET_EGRESS or VPC connector ARN).
+                description:
+                  type: string
+                  description: Human-readable description of this class.

--- a/charts/lambda-vm-ack-operator/templates/clusterrole.yaml
+++ b/charts/lambda-vm-ack-operator/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "lambda-vm-ack-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["lambda.aws.amazon.com"]
-    resources: ["microvms", "microvmpools", "microvmtemplates", "microvmnetworks", "microvmimages"]
+    resources: ["microvms", "microvmpools", "microvmtemplates", "microvmnetworks", "microvmimages", "microvmclasses"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["lambda.aws.amazon.com"]
     resources: ["microvms/status", "microvmpools/status", "microvmimages/status"]

--- a/docs/user-guides/microvm-class.md
+++ b/docs/user-guides/microvm-class.md
@@ -1,0 +1,137 @@
+# MicroVMClass — Runtime Profiles
+
+## Overview
+
+`MicroVMClass` defines a named runtime profile (idle policy, networking, sizing) that platform
+admins create once and developers reference by name via `spec.className` on a `MicroVM`.
+
+This follows the Kubernetes `StorageClass` / `IngressClass` pattern:
+- Admins define what classes are available
+- Developers pick a class by name — no need to know the underlying ARNs or tuning values
+- `spec.className` is **optional** — MicroVMs without a class use their own spec values
+
+## Built-in Profiles (recommended starting point)
+
+### `agentic-standard` — AI agents and interactive sessions
+
+```yaml
+apiVersion: lambda.aws.amazon.com/v1alpha1
+kind: MicroVMClass
+metadata:
+  name: agentic-standard
+  namespace: my-app
+spec:
+  description: "AI coding assistants, interactive dev environments — suspend when idle"
+  maxIdleDurationSeconds: 300        # suspend after 5 min idle
+  suspendedDurationSeconds: 7200     # keep suspended for 2 hr, then terminate
+  autoResumeEnabled: true            # wake up automatically when traffic arrives
+  maximumDurationSeconds: 28800      # 8 hr hard cap
+  ingressNetworkConnectors:
+    - arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:ALL_INGRESS
+  egressNetworkConnectors:
+    - arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:INTERNET_EGRESS
+```
+
+### `batch-job` — CI/CD jobs, security scans, one-shot tasks
+
+```yaml
+apiVersion: lambda.aws.amazon.com/v1alpha1
+kind: MicroVMClass
+metadata:
+  name: batch-job
+  namespace: my-app
+spec:
+  description: "Run-to-completion jobs — no suspend, hard 1 hr cap"
+  autoResumeEnabled: false
+  maximumDurationSeconds: 3600       # 1 hr max
+  ingressNetworkConnectors:
+    - arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:NO_INGRESS
+  egressNetworkConnectors:
+    - arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:INTERNET_EGRESS
+```
+
+### `vpc-agent` — Agents needing private VPC access
+
+```yaml
+apiVersion: lambda.aws.amazon.com/v1alpha1
+kind: MicroVMClass
+metadata:
+  name: vpc-agent
+  namespace: my-app
+spec:
+  description: "Agents that access RDS, ElastiCache, or internal APIs"
+  maxIdleDurationSeconds: 300
+  suspendedDurationSeconds: 3600
+  autoResumeEnabled: true
+  ingressNetworkConnectors:
+    - arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:ALL_INGRESS
+  egressNetworkConnectors:
+    - arn:aws:lambda:us-east-1:123456789012:network-connector:my-vpc-connector  # customer-managed
+```
+
+## Using a MicroVMClass
+
+Reference the class by `spec.className`:
+
+```yaml
+apiVersion: lambda.aws.amazon.com/v1alpha1
+kind: MicroVM
+metadata:
+  name: agent-session-abc123
+spec:
+  imageRef: my-agent-image
+  className: agentic-standard        # ← picks up idle policy + connectors
+  executionRoleArn: arn:aws:iam::123456789012:role/AgentRole
+  runHookPayload: '{"tenantId":"tenant-42","sessionId":"s-abc123"}'
+```
+
+The mutating webhook resolves the class and injects its values at admission time.
+Fields explicitly set in the `MicroVM` spec always take precedence over class values.
+
+## Override class values per-MicroVM
+
+```yaml
+spec:
+  className: agentic-standard
+  maxIdleDurationSeconds: 60   # override: suspend faster for this VM
+  # all other fields from the class apply
+```
+
+## Field precedence
+
+```
+MicroVM spec field explicitly set  →  wins
+MicroVMClass spec field            →  applied if MicroVM field is null
+Global webhook default             →  applied if both are null
+                                      (maximumDurationSeconds=28800, autoResumeEnabled=true)
+```
+
+## Without className (backward compatible)
+
+`className` is always optional. Existing MicroVMs without it continue to work exactly as before.
+
+```yaml
+spec:
+  imageRef: my-image
+  # no className — spec values and global defaults used directly
+  maxIdleDurationSeconds: 900
+  autoResumeEnabled: true
+```
+
+## Listing available classes
+
+```bash
+kubectl get microvmclasses -n my-app
+# NAME               MAXIDLE   AUTORESUME   DESCRIPTION
+# agentic-standard   300       true         AI coding assistants...
+# batch-job          <none>    false        Run-to-completion jobs...
+```
+
+## Cost implications
+
+| Class | Active time | Idle cost | Best for |
+|-------|-------------|-----------|----------|
+| `agentic-standard` | Pay while active | ~$0 when suspended | < 13% utilization |
+| `batch-job` | Pay for job duration | None (terminates) | Predictable jobs |
+
+See [pricing comparison](../aws-microvms-official/01-overview.md) for detailed cost analysis.

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMClass.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMClass.java
@@ -1,0 +1,18 @@
+package ai.codriverlabs.microvm.operator.core.model;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+/**
+ * MicroVMClass defines a named runtime profile (idle policy, networking, sizing) that
+ * can be applied to MicroVM instances by setting spec.className.
+ *
+ * Analogous to Kubernetes StorageClass / IngressClass — admins define classes,
+ * developers reference them. className is optional; without it, MicroVM uses its own spec values.
+ */
+@Group("lambda.aws.amazon.com")
+@Version("v1alpha1")
+public class MicroVMClass extends CustomResource<MicroVMClassSpec, Void> implements Namespaced {
+}

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMClassSpec.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMClassSpec.java
@@ -1,0 +1,57 @@
+package ai.codriverlabs.microvm.operator.core.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Runtime profile spec for MicroVMClass.
+ * All fields are optional — only set fields are merged into the MicroVM spec.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MicroVMClassSpec {
+
+    // --- Idle policy ---
+    /** Seconds without traffic before Lambda auto-suspends the MicroVM. Max 28800 (8h). */
+    private Integer maxIdleDurationSeconds;
+    /** Seconds in SUSPENDED state before Lambda auto-terminates. */
+    private Integer suspendedDurationSeconds;
+    /** When true, a suspended MicroVM auto-resumes when traffic arrives. */
+    private Boolean autoResumeEnabled;
+
+    // --- Lifetime ---
+    /** Hard cap on total MicroVM lifetime (running + suspended). Max 28800 (8h). */
+    private Integer maximumDurationSeconds;
+
+    // --- Networking ---
+    /** Inbound connector ARNs (e.g. ALL_INGRESS). */
+    private List<String> ingressNetworkConnectors;
+    /** Outbound connector ARNs (e.g. INTERNET_EGRESS or VPC connector). */
+    private List<String> egressNetworkConnectors;
+
+    // --- Description ---
+    private String description;
+
+    public Integer getMaxIdleDurationSeconds() { return maxIdleDurationSeconds; }
+    public void setMaxIdleDurationSeconds(Integer v) { this.maxIdleDurationSeconds = v; }
+
+    public Integer getSuspendedDurationSeconds() { return suspendedDurationSeconds; }
+    public void setSuspendedDurationSeconds(Integer v) { this.suspendedDurationSeconds = v; }
+
+    public Boolean getAutoResumeEnabled() { return autoResumeEnabled; }
+    public void setAutoResumeEnabled(Boolean v) { this.autoResumeEnabled = v; }
+
+    public Integer getMaximumDurationSeconds() { return maximumDurationSeconds; }
+    public void setMaximumDurationSeconds(Integer v) { this.maximumDurationSeconds = v; }
+
+    public List<String> getIngressNetworkConnectors() { return ingressNetworkConnectors; }
+    public void setIngressNetworkConnectors(List<String> v) { this.ingressNetworkConnectors = v; }
+
+    public List<String> getEgressNetworkConnectors() { return egressNetworkConnectors; }
+    public void setEgressNetworkConnectors(List<String> v) { this.egressNetworkConnectors = v; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String v) { this.description = v; }
+}

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMSpec.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMSpec.java
@@ -20,6 +20,13 @@ public class MicroVMSpec {
     private String imageRef;
     private String imageVersion;
 
+    /**
+     * Optional reference to a MicroVMClass that defines runtime defaults
+     * (idle policy, networking, sizing). Fields explicitly set in this spec
+     * take precedence over the class values.
+     */
+    private String className;
+
     // Networking — ARNs for inbound/outbound connectors (see docs/aws-microvms-official/05-networking.md)
     private List<String> ingressNetworkConnectors = new ArrayList<>();
     private List<String> egressNetworkConnectors = new ArrayList<>();
@@ -52,6 +59,9 @@ public class MicroVMSpec {
 
     public String getImageVersion() { return imageVersion; }
     public void setImageVersion(String imageVersion) { this.imageVersion = imageVersion; }
+
+    public String getClassName() { return className; }
+    public void setClassName(String className) { this.className = className; }
 
     public List<String> getIngressNetworkConnectors() { return ingressNetworkConnectors; }
     public void setIngressNetworkConnectors(List<String> v) { this.ingressNetworkConnectors = v; }

--- a/operator-tests/src/test/java/ai/codriverlabs/microvm/operator/tests/integration/MicroVMClassIT.java
+++ b/operator-tests/src/test/java/ai/codriverlabs/microvm/operator/tests/integration/MicroVMClassIT.java
@@ -1,0 +1,174 @@
+package ai.codriverlabs.microvm.operator.tests.integration;
+
+import ai.codriverlabs.microvm.operator.core.model.MicroVMClass;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMClassSpec;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMSpec;
+import ai.codriverlabs.microvm.operator.webhook.mutation.MicroVMMutatingWebhook;
+import ai.codriverlabs.microvm.operator.webhook.validation.MicroVMValidatingWebhook;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for MicroVMClass — webhook mutation and validation.
+ */
+@EnableKubernetesMockClient(crud = true)
+class MicroVMClassIT {
+
+    KubernetesClient client;
+
+    private MicroVMMutatingWebhook mutatingWebhook;
+    private MicroVMValidatingWebhook validatingWebhook;
+
+    @BeforeEach
+    void setUp() {
+        mutatingWebhook = new MicroVMMutatingWebhook(null, client);
+        validatingWebhook = new MicroVMValidatingWebhook(client, null);
+    }
+
+    // ---- Mutation tests ----
+
+    @Test
+    @DisplayName("No className: global defaults applied, no class lookup")
+    void noClassName_globalDefaultsApplied() {
+        var spec = new MicroVMSpec();
+        spec.setImageRef("my-image");
+        // className not set
+
+        mutatingWebhook.applyDefaults(spec, "default");
+
+        assertEquals(28800, spec.getMaximumDurationSeconds());
+        assertTrue(spec.getAutoResumeEnabled());
+        assertNull(spec.getMaxIdleDurationSeconds()); // not set by global defaults
+    }
+
+    @Test
+    @DisplayName("className set: class defaults merged into spec")
+    void className_mergesClassDefaults() {
+        createClass("agentic-1st", 300, 7200, true,
+                List.of("arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:ALL_INGRESS"),
+                List.of("arn:aws:lambda:us-east-1:aws:network-connector:aws-network-connector:INTERNET_EGRESS"));
+
+        var spec = new MicroVMSpec();
+        spec.setImageRef("my-image");
+        spec.setClassName("agentic-1st");
+
+        mutatingWebhook.applyDefaults(spec, "default");
+
+        assertEquals(300, spec.getMaxIdleDurationSeconds());
+        assertEquals(7200, spec.getSuspendedDurationSeconds());
+        assertTrue(spec.getAutoResumeEnabled());
+        assertEquals(1, spec.getIngressNetworkConnectors().size());
+        assertTrue(spec.getIngressNetworkConnectors().get(0).contains("ALL_INGRESS"));
+        assertEquals(1, spec.getEgressNetworkConnectors().size());
+    }
+
+    @Test
+    @DisplayName("spec fields take precedence over class defaults")
+    void specFieldsTakePrecedenceOverClass() {
+        createClass("agentic-1st", 300, 7200, true, null, null);
+
+        var spec = new MicroVMSpec();
+        spec.setImageRef("my-image");
+        spec.setClassName("agentic-1st");
+        spec.setMaxIdleDurationSeconds(600); // explicitly set — should NOT be overwritten
+
+        mutatingWebhook.applyDefaults(spec, "default");
+
+        assertEquals(600, spec.getMaxIdleDurationSeconds()); // preserved
+        assertEquals(7200, spec.getSuspendedDurationSeconds()); // from class
+    }
+
+    @Test
+    @DisplayName("className set but class not found: no error, global defaults applied")
+    void className_notFound_fallsBackToGlobalDefaults() {
+        var spec = new MicroVMSpec();
+        spec.setImageRef("my-image");
+        spec.setClassName("nonexistent-class");
+
+        // Should not throw — FailurePolicy: Ignore
+        assertDoesNotThrow(() -> mutatingWebhook.applyDefaults(spec, "default"));
+        assertEquals(28800, spec.getMaximumDurationSeconds()); // global default applied
+    }
+
+    @Test
+    @DisplayName("class has no ingressConnectors: spec connectors unchanged")
+    void class_withoutConnectors_doesNotClearSpecConnectors() {
+        createClass("minimal-class", 300, null, null, null, null);
+
+        var spec = new MicroVMSpec();
+        spec.setImageRef("my-image");
+        spec.setClassName("minimal-class");
+        spec.setIngressNetworkConnectors(List.of("arn:my-custom-ingress"));
+
+        mutatingWebhook.applyDefaults(spec, "default");
+
+        assertEquals(List.of("arn:my-custom-ingress"), spec.getIngressNetworkConnectors());
+    }
+
+    // ---- Validation tests ----
+
+    @Test
+    @DisplayName("Validation: no className → no error")
+    void validation_noClassName_noError() {
+        var spec = new MicroVMSpec();
+        spec.setImageRef("my-image");
+
+        var errors = new java.util.ArrayList<String>();
+        validatingWebhook.validateClassName(spec, "default", errors);
+
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Validation: className exists → no error")
+    void validation_classNameExists_noError() {
+        createClass("agentic-1st", 300, 7200, true, null, null);
+
+        var spec = new MicroVMSpec();
+        spec.setImageRef("my-image");
+        spec.setClassName("agentic-1st");
+
+        var errors = new java.util.ArrayList<String>();
+        validatingWebhook.validateClassName(spec, "default", errors);
+
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Validation: className not found → error")
+    void validation_classNameNotFound_error() {
+        var spec = new MicroVMSpec();
+        spec.setImageRef("my-image");
+        spec.setClassName("does-not-exist");
+
+        var errors = new java.util.ArrayList<String>();
+        validatingWebhook.validateClassName(spec, "default", errors);
+
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("does-not-exist"));
+    }
+
+    // ---- helpers ----
+
+    private void createClass(String name, Integer maxIdle, Integer suspendedDuration,
+                              Boolean autoResume, List<String> ingress, List<String> egress) {
+        var clazz = new MicroVMClass();
+        clazz.setMetadata(new ObjectMetaBuilder().withName(name).withNamespace("default").build());
+        var spec = new MicroVMClassSpec();
+        spec.setMaxIdleDurationSeconds(maxIdle);
+        spec.setSuspendedDurationSeconds(suspendedDuration);
+        spec.setAutoResumeEnabled(autoResume);
+        spec.setIngressNetworkConnectors(ingress);
+        spec.setEgressNetworkConnectors(egress);
+        clazz.setSpec(spec);
+        client.resource(clazz).create();
+    }
+}

--- a/operator-webhook/src/main/java/ai/codriverlabs/microvm/operator/webhook/mutation/MicroVMMutatingWebhook.java
+++ b/operator-webhook/src/main/java/ai/codriverlabs/microvm/operator/webhook/mutation/MicroVMMutatingWebhook.java
@@ -1,11 +1,14 @@
 package ai.codriverlabs.microvm.operator.webhook.mutation;
 
 import ai.codriverlabs.microvm.operator.core.model.MicroVM;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMClass;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMClassSpec;
 import ai.codriverlabs.microvm.operator.core.model.MicroVMSpec;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
@@ -20,45 +23,90 @@ import java.util.List;
 
 /**
  * Mutating admission webhook for MicroVM resources.
- * Applies defaults for optional fields when not specified.
- * FailurePolicy: Ignore
+ * - Applies spec.className defaults from MicroVMClass (if set)
+ * - Applies global defaults for unset fields
+ * FailurePolicy: Ignore — webhook errors never block admission
  */
 @Path("/mutate-microvm")
 public class MicroVMMutatingWebhook {
 
     private static final Logger LOG = Logger.getLogger(MicroVMMutatingWebhook.class);
-    
-    private static final int DEFAULT_MAX_DURATION = 28800;
 
     private final ObjectMapper objectMapper;
+    private final KubernetesClient kubernetesClient;
 
-    /**
-     * No-arg constructor for unit testing.
-     */
+    /** No-arg constructor for unit testing without CDI. */
     public MicroVMMutatingWebhook() {
         this.objectMapper = null;
+        this.kubernetesClient = null;
     }
 
     @Inject
-    public MicroVMMutatingWebhook(ObjectMapper objectMapper) {
+    public MicroVMMutatingWebhook(ObjectMapper objectMapper, KubernetesClient kubernetesClient) {
         this.objectMapper = objectMapper;
+        this.kubernetesClient = kubernetesClient;
     }
 
     /**
-     * Applies default values to a MicroVMSpec for fields that are not set.
-     * This method is extracted for unit testability.
+     * Merges MicroVMClass defaults into spec, then applies global defaults.
+     * Fields already set in spec are never overwritten.
+     * className itself is optional — if null/blank, this is a no-op for class resolution.
      *
-     * @param spec the MicroVMSpec to apply defaults to
-     * @return the spec with defaults applied (same object, mutated in place)
+     * @param spec      MicroVMSpec to apply defaults to (mutated in place)
+     * @param namespace namespace to look up the MicroVMClass in
+     * @return the spec with defaults applied
      */
-    public MicroVMSpec applyDefaults(MicroVMSpec spec) {
+    public MicroVMSpec applyDefaults(MicroVMSpec spec, String namespace) {
+        // 1. Merge MicroVMClass defaults (spec fields take precedence)
+        String className = spec.getClassName();
+        if (className != null && !className.isBlank() && kubernetesClient != null) {
+            try {
+                MicroVMClass clazz = kubernetesClient.resources(MicroVMClass.class)
+                        .inNamespace(namespace).withName(className).get();
+                if (clazz != null && clazz.getSpec() != null) {
+                    mergeClassDefaults(spec, clazz.getSpec());
+                    LOG.debugf("Applied MicroVMClass '%s' defaults to MicroVM in namespace '%s'",
+                            className, namespace);
+                }
+            } catch (Exception e) {
+                LOG.warnf("Could not resolve MicroVMClass '%s': %s — skipping class defaults",
+                        className, e.getMessage());
+            }
+        }
+
+        // 2. Apply global defaults for any still-unset fields
         if (spec.getMaximumDurationSeconds() == null) {
             spec.setMaximumDurationSeconds(28800);
         }
         if (spec.getAutoResumeEnabled() == null) {
             spec.setAutoResumeEnabled(true);
         }
+
         return spec;
+    }
+
+    /** Copies fields from MicroVMClass into spec only where spec has no value. */
+    private void mergeClassDefaults(MicroVMSpec spec, MicroVMClassSpec classSpec) {
+        if (spec.getMaxIdleDurationSeconds() == null && classSpec.getMaxIdleDurationSeconds() != null) {
+            spec.setMaxIdleDurationSeconds(classSpec.getMaxIdleDurationSeconds());
+        }
+        if (spec.getSuspendedDurationSeconds() == null && classSpec.getSuspendedDurationSeconds() != null) {
+            spec.setSuspendedDurationSeconds(classSpec.getSuspendedDurationSeconds());
+        }
+        if (spec.getAutoResumeEnabled() == null && classSpec.getAutoResumeEnabled() != null) {
+            spec.setAutoResumeEnabled(classSpec.getAutoResumeEnabled());
+        }
+        if (spec.getMaximumDurationSeconds() == null && classSpec.getMaximumDurationSeconds() != null) {
+            spec.setMaximumDurationSeconds(classSpec.getMaximumDurationSeconds());
+        }
+        if ((spec.getIngressNetworkConnectors() == null || spec.getIngressNetworkConnectors().isEmpty())
+                && classSpec.getIngressNetworkConnectors() != null) {
+            spec.setIngressNetworkConnectors(classSpec.getIngressNetworkConnectors());
+        }
+        if ((spec.getEgressNetworkConnectors() == null || spec.getEgressNetworkConnectors().isEmpty())
+                && classSpec.getEgressNetworkConnectors() != null) {
+            spec.setEgressNetworkConnectors(classSpec.getEgressNetworkConnectors());
+        }
     }
 
     @POST
@@ -67,27 +115,43 @@ public class MicroVMMutatingWebhook {
     public AdmissionReview mutate(AdmissionReview review) {
         AdmissionRequest request = review.getRequest();
         LOG.infof("Mutating MicroVM admission request: %s/%s, operation=%s",
-            request.getNamespace(), request.getName(), request.getOperation());
+                request.getNamespace(), request.getName(), request.getOperation());
 
         List<String> patches = new ArrayList<>();
 
         try {
-            Object rawObject = request.getObject();
-            MicroVM microVM = objectMapper.convertValue(rawObject, MicroVM.class);
+            MicroVM microVM = objectMapper.convertValue(request.getObject(), MicroVM.class);
             MicroVMSpec spec = microVM.getSpec();
 
             if (spec != null) {
-                // Apply default timeoutSeconds if not set
-                if (spec.getAutoResumeEnabled() == null) {
-                }
+                MicroVMSpec before = objectMapper.convertValue(
+                        objectMapper.writeValueAsString(spec), MicroVMSpec.class);
+                applyDefaults(spec, request.getNamespace());
 
-                // Apply default memoryMB if not set
-                if (spec.getMaximumDurationSeconds() == null) {
+                // Build JSON patches for fields that changed
+                if (spec.getMaximumDurationSeconds() != null
+                        && !spec.getMaximumDurationSeconds().equals(before.getMaximumDurationSeconds())) {
+                    patches.add(buildJsonPatchOp("add", "/spec/maximumDurationSeconds",
+                            spec.getMaximumDurationSeconds()));
+                }
+                if (spec.getAutoResumeEnabled() != null
+                        && !spec.getAutoResumeEnabled().equals(before.getAutoResumeEnabled())) {
+                    patches.add(buildJsonPatchOp("add", "/spec/autoResumeEnabled",
+                            spec.getAutoResumeEnabled()));
+                }
+                if (spec.getMaxIdleDurationSeconds() != null
+                        && !spec.getMaxIdleDurationSeconds().equals(before.getMaxIdleDurationSeconds())) {
+                    patches.add(buildJsonPatchOp("add", "/spec/maxIdleDurationSeconds",
+                            spec.getMaxIdleDurationSeconds()));
+                }
+                if (spec.getSuspendedDurationSeconds() != null
+                        && !spec.getSuspendedDurationSeconds().equals(before.getSuspendedDurationSeconds())) {
+                    patches.add(buildJsonPatchOp("add", "/spec/suspendedDurationSeconds",
+                            spec.getSuspendedDurationSeconds()));
                 }
             }
         } catch (Exception e) {
             LOG.errorf(e, "Error mutating MicroVM admission request");
-            // On error, allow without mutation (failurePolicy: Ignore)
             return buildAllowedResponse(review);
         }
 
@@ -95,7 +159,7 @@ public class MicroVMMutatingWebhook {
     }
 
     private String buildJsonPatchOp(String op, String path, Object value) {
-        if (value instanceof Number) {
+        if (value instanceof Number || value instanceof Boolean) {
             return String.format("{\"op\":\"%s\",\"path\":\"%s\",\"value\":%s}", op, path, value);
         }
         return String.format("{\"op\":\"%s\",\"path\":\"%s\",\"value\":\"%s\"}", op, path, value);
@@ -105,13 +169,11 @@ public class MicroVMMutatingWebhook {
         AdmissionResponse response = new AdmissionResponse();
         response.setUid(review.getRequest().getUid());
         response.setAllowed(true);
-
         if (!patches.isEmpty()) {
             String patchJson = "[" + String.join(",", patches) + "]";
             response.setPatchType("JSONPatch");
             response.setPatch(Base64.getEncoder().encodeToString(patchJson.getBytes()));
         }
-
         AdmissionReview responseReview = new AdmissionReview();
         responseReview.setResponse(response);
         return responseReview;
@@ -121,7 +183,6 @@ public class MicroVMMutatingWebhook {
         AdmissionResponse response = new AdmissionResponse();
         response.setUid(review.getRequest().getUid());
         response.setAllowed(true);
-
         AdmissionReview responseReview = new AdmissionReview();
         responseReview.setResponse(response);
         return responseReview;

--- a/operator-webhook/src/main/java/ai/codriverlabs/microvm/operator/webhook/validation/MicroVMValidatingWebhook.java
+++ b/operator-webhook/src/main/java/ai/codriverlabs/microvm/operator/webhook/validation/MicroVMValidatingWebhook.java
@@ -79,7 +79,23 @@ public class MicroVMValidatingWebhook {
         return errors;
     }
 
-    @POST
+    public void validateClassName(MicroVMSpec spec, String namespace, List<String> errors) {
+        String className = spec.getClassName();
+        if (className == null || className.isBlank()) return; // optional — no-op
+        if (kubernetesClient == null) return;
+        try {
+            var clazz = kubernetesClient.resources(
+                    ai.codriverlabs.microvm.operator.core.model.MicroVMClass.class)
+                    .inNamespace(namespace).withName(className).get();
+            if (clazz == null) {
+                errors.add(String.format(
+                        "spec.className '%s' not found in namespace '%s'", className, namespace));
+            }
+        } catch (Exception e) {
+            LOG.warnf("Error looking up MicroVMClass %s/%s: %s", namespace, className, e.getMessage());
+        }
+    }
+
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public AdmissionReview validate(AdmissionReview review) {
@@ -103,6 +119,7 @@ public class MicroVMValidatingWebhook {
                 validateRuntime(spec, errors);
                 validateTimeout(spec, errors);
                 validateNetworkRef(spec, request.getNamespace(), errors);
+                validateClassName(spec, request.getNamespace(), errors);
             }
 
             // Validate namespace permission

--- a/operator-webhook/src/test/java/ai/codriverlabs/microvm/operator/webhook/MicroVMMutatingWebhookTest.java
+++ b/operator-webhook/src/test/java/ai/codriverlabs/microvm/operator/webhook/MicroVMMutatingWebhookTest.java
@@ -24,7 +24,7 @@ class MicroVMMutatingWebhookTest {
         spec.setMaximumDurationSeconds(null);
         spec.setMaxIdleDurationSeconds(2);
 
-        MicroVMSpec mutated = webhook.applyDefaults(spec);
+        MicroVMSpec mutated = webhook.applyDefaults(spec, "default");
         assertEquals(28800, mutated.getMaximumDurationSeconds());
     }
 
@@ -35,7 +35,7 @@ class MicroVMMutatingWebhookTest {
         spec.setMaximumDurationSeconds(512);
         spec.setAutoResumeEnabled(null);
 
-        MicroVMSpec mutated = webhook.applyDefaults(spec);
+        MicroVMSpec mutated = webhook.applyDefaults(spec, "default");
         assertTrue(mutated.getAutoResumeEnabled());
     }
 
@@ -46,7 +46,7 @@ class MicroVMMutatingWebhookTest {
         spec.setMaximumDurationSeconds(1024);
         spec.setMaxIdleDurationSeconds(4);
 
-        MicroVMSpec mutated = webhook.applyDefaults(spec);
+        MicroVMSpec mutated = webhook.applyDefaults(spec, "default");
         assertEquals(1024, mutated.getMaximumDurationSeconds());
     }
 
@@ -57,7 +57,7 @@ class MicroVMMutatingWebhookTest {
         spec.setMaximumDurationSeconds(512);
         spec.setAutoResumeEnabled(false);
 
-        MicroVMSpec mutated = webhook.applyDefaults(spec);
+        MicroVMSpec mutated = webhook.applyDefaults(spec, "default");
         assertFalse(mutated.getAutoResumeEnabled());
     }
 
@@ -71,7 +71,7 @@ class MicroVMMutatingWebhookTest {
         spec.setNetworkRef("my-network");
         spec.setRegion("eu-west-1");
 
-        MicroVMSpec mutated = webhook.applyDefaults(spec);
+        MicroVMSpec mutated = webhook.applyDefaults(spec, "default");
         assertEquals("python-sandbox", mutated.getImageRef());
         assertEquals(768, mutated.getMaximumDurationSeconds());
         assertEquals(3, mutated.getMaxIdleDurationSeconds());

--- a/operator-webhook/src/test/java/ai/codriverlabs/microvm/operator/webhook/WebhookIntegrationTest.java
+++ b/operator-webhook/src/test/java/ai/codriverlabs/microvm/operator/webhook/WebhookIntegrationTest.java
@@ -37,7 +37,7 @@ class WebhookIntegrationTest {
         // autoResumeEnabled is null - should get default
 
         // Step 1: Mutate
-        MicroVMSpec mutated = mutator.applyDefaults(spec);
+        MicroVMSpec mutated = mutator.applyDefaults(spec, "default");
         assertEquals(512, mutated.getMaximumDurationSeconds()); // explicit, not overridden
         assertTrue(mutated.getAutoResumeEnabled()); // defaulted
 
@@ -108,7 +108,7 @@ class WebhookIntegrationTest {
         spec.setSuspendedDurationSeconds(600);
         spec.setNetworkRef("custom-network");
 
-        MicroVMSpec mutated = mutator.applyDefaults(spec);
+        MicroVMSpec mutated = mutator.applyDefaults(spec, "default");
 
         assertEquals("python-sandbox", mutated.getImageRef());
         assertEquals(1024, mutated.getMaximumDurationSeconds());

--- a/operator-webhook/src/test/java/ai/codriverlabs/microvm/operator/webhook/WebhookMutationPropertyTest.java
+++ b/operator-webhook/src/test/java/ai/codriverlabs/microvm/operator/webhook/WebhookMutationPropertyTest.java
@@ -18,14 +18,14 @@ class WebhookMutationPropertyTest {
 
     @Property(tries = 100)
     void nullMaxDurationGetsDefault(@ForAll("specWithNullMaxDuration") MicroVMSpec spec) {
-        MicroVMSpec mutated = webhook.applyDefaults(spec);
+        MicroVMSpec mutated = webhook.applyDefaults(spec, "default");
         assert mutated.getMaximumDurationSeconds() == 28800 :
             "Null maximumDurationSeconds should default to 28800, got: " + mutated.getMaximumDurationSeconds();
     }
 
     @Property(tries = 100)
     void nullAutoResumeGetsDefault(@ForAll("specWithNullAutoResume") MicroVMSpec spec) {
-        MicroVMSpec mutated = webhook.applyDefaults(spec);
+        MicroVMSpec mutated = webhook.applyDefaults(spec, "default");
         assert mutated.getAutoResumeEnabled() == true :
             "Null autoResumeEnabled should default to true, got: " + mutated.getAutoResumeEnabled();
     }
@@ -33,7 +33,7 @@ class WebhookMutationPropertyTest {
     @Property(tries = 100)
     void explicitMaxDurationPreserved(@ForAll("specWithExplicitMaxDuration") MicroVMSpec spec) {
         Integer original = spec.getMaximumDurationSeconds();
-        MicroVMSpec mutated = webhook.applyDefaults(spec);
+        MicroVMSpec mutated = webhook.applyDefaults(spec, "default");
         assert mutated.getMaximumDurationSeconds().equals(original) :
             "Explicit maximumDurationSeconds " + original + " should be preserved, got: " + mutated.getMaximumDurationSeconds();
     }
@@ -46,7 +46,7 @@ class WebhookMutationPropertyTest {
         String originalRegion = spec.getRegion();
         DesiredState originalDesired = spec.getDesiredState();
 
-        webhook.applyDefaults(spec);
+        webhook.applyDefaults(spec, "default");
 
         assert Objects.equals(spec.getImageRef(), originalImageRef) : "ImageRef changed";
         assert Objects.equals(spec.getMaxIdleDurationSeconds(), originalVcpus) : "MaxIdleDurationSeconds changed";


### PR DESCRIPTION
## Summary

Introduces `MicroVMClass` CRD — platform admins define named runtime profiles, developers reference them via optional `spec.className`.

## Usage
```yaml
kind: MicroVMClass
metadata: {name: agentic-standard}
spec:
  maxIdleDurationSeconds: 300
  suspendedDurationSeconds: 7200
  autoResumeEnabled: true
  ingressNetworkConnectors: [arn:...:ALL_INGRESS]
  egressNetworkConnectors: [arn:...:INTERNET_EGRESS]
---
kind: MicroVM
spec:
  imageRef: my-agent-image
  className: agentic-standard  # optional
```

## Tests: 23 total, all green (8 new MicroVMClassIT)
## Docs: docs/user-guides/microvm-class.md