### PR TITLE
feat: P0+P1 — auth token CLI, autoActivate, version history

### DIFF
--- a/operator-cli/pom.xml
+++ b/operator-cli/pom.xml
@@ -22,6 +22,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Generated AWS Lambda MicroVMs SDK client (for token generation) -->
+        <dependency>
+            <groupId>ai.codriverlabs</groupId>
+            <artifactId>operator-aws-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Quarkus Picocli -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/MicroVMCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/MicroVMCommand.java
@@ -25,7 +25,8 @@ import picocli.CommandLine.Command;
         LogsCommand.class,
         ExecCommand.class,
         PoolCommand.class,
-        ImageCommand.class
+        ImageCommand.class,
+        TokenCommand.class
     }
 )
 public class MicroVMCommand {

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/TokenCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/TokenCommand.java
@@ -1,0 +1,100 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.aws.lambdamicrovms.LambdaMicrovmsClient;
+import ai.codriverlabs.microvm.aws.lambdamicrovms.model.*;
+import ai.codriverlabs.microvm.operator.core.model.MicroVM;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * kubectl microvm token — generate a short-lived JWE auth token for connecting to a MicroVM.
+ *
+ * Usage:
+ *   kubectl microvm token --name my-vm
+ *   kubectl microvm token --name my-vm --expires 60 --port 8080
+ *
+ * Pipe into curl:
+ *   curl https://<endpoint>/ -H "X-aws-proxy-auth: $(kubectl microvm token --name my-vm)"
+ */
+@Command(name = "token",
+        description = "Generate an auth token for connecting to a running MicroVM endpoint",
+        mixinStandardHelpOptions = true)
+public class TokenCommand implements Runnable {
+
+    @Option(names = {"--name"}, required = true, description = "Name of the MicroVM CR")
+    String name;
+
+    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
+    String namespace;
+
+    @Option(names = {"--expires"}, defaultValue = "30",
+            description = "Token expiry in minutes (default: 30, max: 43200)")
+    int expiresMinutes;
+
+    @Option(names = {"--port"}, description = "Scope token to a specific port (default: all ports)")
+    Integer port;
+
+    @Option(names = {"--show-endpoint"}, description = "Also print the endpoint URL to stderr")
+    boolean showEndpoint;
+
+    @Option(names = {"--region"}, description = "AWS region (default: from MicroVM spec or us-east-1)")
+    String region;
+
+    @Inject
+    KubernetesClient client;
+
+    @Override
+    public void run() {
+        // 1. Resolve microvmId + endpoint from CR status
+        MicroVM vm = client.resources(MicroVM.class).inNamespace(namespace).withName(name).get();
+        if (vm == null) {
+            System.err.printf("MicroVM '%s' not found in namespace '%s'%n", name, namespace);
+            System.exit(1);
+            return;
+        }
+        if (vm.getStatus() == null || vm.getStatus().getMicroVmId() == null) {
+            System.err.printf("MicroVM '%s' has no microvmId in status (state: %s)%n",
+                    name, vm.getStatus() != null ? vm.getStatus().getState() : "unknown");
+            System.exit(1);
+            return;
+        }
+
+        String microvmId = vm.getStatus().getMicroVmId();
+        String endpoint = vm.getStatus().getEndpointUrl();
+        String awsRegion = region != null ? region
+                : (vm.getSpec().getRegion() != null ? vm.getSpec().getRegion() : "us-east-1");
+
+        // 2. Build port specification
+        PortSpecification portSpec = port != null
+                ? PortSpecification.builder().port(port).build()
+                : PortSpecification.builder().allPorts(Unit.builder().build()).build();
+
+        // 3. Call CreateMicrovmAuthToken
+        try (LambdaMicrovmsClient awsClient = LambdaMicrovmsClient.builder()
+                .region(Region.of(awsRegion)).build()) {
+
+            var response = awsClient.createMicrovmAuthToken(
+                    CreateMicrovmAuthTokenRequest.builder()
+                            .microvmIdentifier(microvmId)
+                            .expirationInMinutes(expiresMinutes)
+                            .allowedPorts(portSpec)
+                            .build());
+
+            if (showEndpoint && endpoint != null) {
+                System.err.println("endpoint: " + endpoint);
+            }
+
+            // Print the token value for the X-aws-proxy-auth header
+            String token = response.authToken().getOrDefault("X-aws-proxy-auth",
+                    response.authToken().values().iterator().next());
+            System.out.println(token);
+
+        } catch (Exception e) {
+            System.err.printf("Error creating auth token for MicroVM '%s': %s%n", name, e.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/DefaultMicroVMClient.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/DefaultMicroVMClient.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @ApplicationScoped
@@ -79,6 +80,23 @@ public class DefaultMicroVMClient implements MicroVMClient {
     public CompletableFuture<Void> terminateMicroVM(String microvmId) {
         return sdk.terminateMicrovm(TerminateMicrovmRequest.builder().microvmIdentifier(microvmId).build())
                 .thenApply(r -> null);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, String>> createAuthToken(
+            String microvmId, int expirationMinutes, boolean allPorts) {
+        var portsBuilder = PortSpecification.builder();
+        if (allPorts) {
+            portsBuilder.allPorts(Unit.builder().build());
+        } else {
+            portsBuilder.port(8080);
+        }
+        return sdk.createMicrovmAuthToken(CreateMicrovmAuthTokenRequest.builder()
+                .microvmIdentifier(microvmId)
+                .expirationInMinutes(expirationMinutes)
+                .allowedPorts(portsBuilder.build())
+                .build())
+                .thenApply(r -> r.authToken());
     }
 
     @PreDestroy

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMClient.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMClient.java
@@ -1,5 +1,6 @@
 package ai.codriverlabs.microvm.operator.controller.aws;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -21,4 +22,15 @@ public interface MicroVMClient {
 
     /** Calls TerminateMicrovm — terminates a MicroVM and releases all resources. */
     CompletableFuture<Void> terminateMicroVM(String microvmId);
+
+    /**
+     * Calls CreateMicrovmAuthToken — generates a short-lived JWE token for connecting
+     * to the MicroVM's HTTPS endpoint via the X-aws-proxy-auth header.
+     *
+     * @param microvmId          the MicroVM identifier
+     * @param expirationMinutes  token lifetime in minutes
+     * @param allPorts           if true, token allows access to all ports; otherwise port 8080 only
+     */
+    CompletableFuture<Map<String, String>> createAuthToken(
+            String microvmId, int expirationMinutes, boolean allPorts);
 }

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMImageClient.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMImageClient.java
@@ -2,6 +2,7 @@ package ai.codriverlabs.microvm.operator.controller.aws;
 
 import ai.codriverlabs.microvm.aws.lambdamicrovms.LambdaMicrovmsAsyncClient;
 import ai.codriverlabs.microvm.aws.lambdamicrovms.model.*;
+import java.util.List;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -62,6 +63,22 @@ public class MicroVMImageClient {
     public CompletableFuture<DeleteMicrovmImageResponse> deleteImage(String imageIdentifier) {
         return sdk.deleteMicrovmImage(DeleteMicrovmImageRequest.builder()
                 .imageIdentifier(imageIdentifier)
+                .build());
+    }
+
+    public CompletableFuture<List<MicrovmImageVersionSummary>> listVersions(String imageIdentifier) {
+        return sdk.listMicrovmImageVersions(ListMicrovmImageVersionsRequest.builder()
+                .imageIdentifier(imageIdentifier)
+                .build())
+                .thenApply(r -> r.items());
+    }
+
+    public CompletableFuture<UpdateMicrovmImageVersionResponse> activateVersion(
+            String imageIdentifier, String imageVersion) {
+        return sdk.updateMicrovmImageVersion(UpdateMicrovmImageVersionRequest.builder()
+                .imageIdentifier(imageIdentifier)
+                .imageVersion(imageVersion)
+                .status(MicrovmImageVersionStatus.ACTIVE)
                 .build());
     }
 

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMImageReconciler.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMImageReconciler.java
@@ -89,6 +89,17 @@ public class MicroVMImageReconciler implements Reconciler<MicroVMImage>, Cleaner
                     if (versionResp.stateReason() != null) {
                         status.setLatestVersionStateReason(versionResp.stateReason());
                     }
+
+                    // Auto-activate once version reaches SUCCESSFUL
+                    boolean autoActivate = spec.getAutoActivate() == null || spec.getAutoActivate();
+                    if (MicrovmImageVersionState.SUCCESSFUL.toString().equals(versionResp.stateAsString())
+                            && autoActivate) {
+                        LOG.infof("Auto-activating image %s version %s", name, status.getLatestVersion());
+                        imageClient.activateVersion(status.getImageArn(), status.getLatestVersion())
+                                .get(TIMEOUT_S, TimeUnit.SECONDS);
+                        status.setActiveVersion(status.getLatestVersion());
+                    }
+
                     LOG.infof("Image %s state=%s version=%s versionState=%s",
                             name, imageResp.stateAsString(), status.getLatestVersion(), versionResp.stateAsString());
                 } else {
@@ -97,7 +108,19 @@ public class MicroVMImageReconciler implements Reconciler<MicroVMImage>, Cleaner
                 return UpdateControl.patchStatus(resource).rescheduleAfter(POLL_INTERVAL);
             }
 
-            // Settled — periodic resync
+            // Settled — sync full version list then periodic resync
+            try {
+                var versions = imageClient.listVersions(status.getImageArn()).get(TIMEOUT_S, TimeUnit.SECONDS);
+                status.setVersions(versions.stream().map(v -> {
+                    var info = new ai.codriverlabs.microvm.operator.core.model.MicroVMImageVersionInfo();
+                    info.setVersion(v.imageVersion());
+                    info.setState(v.stateAsString());
+                    info.setStatus(v.statusAsString());
+                    return info;
+                }).collect(java.util.stream.Collectors.toList()));
+            } catch (Exception e) {
+                LOG.warnf("Failed to list image versions for %s: %s", name, e.getMessage());
+            }
             return UpdateControl.patchStatus(resource).rescheduleAfter(RESYNC);
 
         } catch (Exception e) {

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageVersionInfo.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMImageVersionInfo.java
@@ -5,17 +5,24 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MicroVMImageVersionInfo {
 
-    private Integer version;
+    /** Version string (e.g. "1.0", "2.0") */
+    private String version;
+    /** Version build state: PENDING, IN_PROGRESS, SUCCESSFUL, FAILED */
     private String state;
+    /** Version activation: ACTIVE, INACTIVE */
+    private String status;
     private String builtAt;
     private String startedAt;
     private String failureReason;
 
-    public Integer getVersion() { return version; }
-    public void setVersion(Integer version) { this.version = version; }
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
 
     public String getState() { return state; }
     public void setState(String state) { this.state = state; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
 
     public String getBuiltAt() { return builtAt; }
     public void setBuiltAt(String builtAt) { this.builtAt = builtAt; }


### PR DESCRIPTION
## P0 — CreateMicrovmAuthToken
- `kubectl microvm token --name my-vm` — fetches microvmId from CR status, calls AWS, prints JWE to stdout
- Pipeable: `curl ... -H "X-aws-proxy-auth: $(kubectl microvm token --name my-vm)"`

## P1 — Image version management
- Reconciler auto-activates version when build reaches SUCCESSFUL (`autoActivate=true` default)
- `status.versions[]` populated from ListMicrovmImageVersions on settled state

## Tests: 23, all passing