### PR TITLE
feat: P2+P3 — tag sync, ListMicrovms, shell auth, build info

### DIFF
--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ExecCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ExecCommand.java
@@ -1,61 +1,98 @@
 package ai.codriverlabs.microvm.operator.cli.commands;
 
+import ai.codriverlabs.microvm.aws.lambdamicrovms.LambdaMicrovmsClient;
+import ai.codriverlabs.microvm.aws.lambdamicrovms.model.CreateMicrovmShellAuthTokenRequest;
 import ai.codriverlabs.microvm.operator.core.model.MicroVM;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import jakarta.inject.Inject;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
+import software.amazon.awssdk.regions.Region;
 
 import java.util.List;
 
-@Command(name = "exec", description = "Execute a command in a MicroVM", mixinStandardHelpOptions = true)
+/**
+ * kubectl microvm exec — open a shell session in a running MicroVM.
+ *
+ * Prints the shell auth token and WebSocket endpoint so the user can connect
+ * with a WebSocket client. Direct terminal multiplexing is outside the CLI scope.
+ *
+ * Usage:
+ *   kubectl microvm exec my-vm
+ *   kubectl microvm exec my-vm --show-token   # print raw token for scripting
+ */
+@Command(name = "exec", description = "Get shell access credentials for a running MicroVM",
+        mixinStandardHelpOptions = true)
 public class ExecCommand implements Runnable {
 
     @Parameters(index = "0", description = "Name of the MicroVM")
     String name;
 
-    @Parameters(index = "1..*", description = "Command to execute")
+    @Parameters(index = "1..*", description = "Command hint (for display only)", arity = "0..*")
     List<String> command;
 
-    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace (default: default)")
+    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
     String namespace;
+
+    @Option(names = {"--expires"}, defaultValue = "30", description = "Token expiry in minutes")
+    int expiresMinutes;
+
+    @Option(names = {"--show-token"}, description = "Print raw shell auth token only")
+    boolean showToken;
+
+    @Option(names = {"--region"}, description = "AWS region")
+    String region;
 
     @Inject
     KubernetesClient client;
 
     @Override
     public void run() {
-        try {
-            MicroVM vm = client.resources(MicroVM.class)
-                .inNamespace(namespace)
-                .withName(name)
-                .get();
+        MicroVM vm = client.resources(MicroVM.class).inNamespace(namespace).withName(name).get();
+        if (vm == null) {
+            System.err.printf("MicroVM '%s' not found in namespace '%s'%n", name, namespace);
+            System.exit(1);
+            return;
+        }
+        if (vm.getStatus() == null || vm.getStatus().getMicroVmId() == null) {
+            System.err.printf("MicroVM '%s' has no microvmId in status (state: %s)%n",
+                    name, vm.getStatus() != null ? vm.getStatus().getState() : "unknown");
+            System.exit(1);
+            return;
+        }
 
-            if (vm == null) {
-                System.err.printf("Error: MicroVM \"%s\" not found in namespace \"%s\"%n", name, namespace);
-                System.exit(1);
+        String microvmId = vm.getStatus().getMicroVmId();
+        String endpoint = vm.getStatus().getEndpointUrl();
+        String awsRegion = region != null ? region
+                : (vm.getSpec().getRegion() != null ? vm.getSpec().getRegion() : "us-east-1");
+
+        try (LambdaMicrovmsClient awsClient = LambdaMicrovmsClient.builder()
+                .region(Region.of(awsRegion)).build()) {
+
+            var response = awsClient.createMicrovmShellAuthToken(
+                    CreateMicrovmShellAuthTokenRequest.builder()
+                            .microvmIdentifier(microvmId)
+                            .expirationInMinutes(expiresMinutes)
+                            .build());
+
+            String token = response.authToken().getOrDefault("X-aws-proxy-auth",
+                    response.authToken().values().iterator().next());
+
+            if (showToken) {
+                System.out.println(token);
+            } else {
+                System.out.printf("MicroVM: %s%n", name);
+                System.out.printf("Endpoint: wss://%s/aws/lambda-microvms/runtime/v1/shell%n", endpoint);
+                System.out.printf("Token (X-aws-proxy-auth): %s%n", token);
+                System.out.println();
+                System.out.println("Connect with a WebSocket client using subprotocols:");
+                System.out.printf("  lambda-microvms%n");
+                System.out.printf("  lambda-microvms.authentication.%s%n", token);
             }
 
-            if (vm.getStatus() == null || vm.getStatus().getMicroVmId() == null) {
-                System.err.printf("Error: MicroVM \"%s\" has no VM ID (not yet created)%n", name);
-                System.exit(1);
-            }
-
-            String commandStr = command != null ? String.join(" ", command) : "";
-            // In real implementation, this would send the command to the MicroVM
-            // via the AWS Lambda MicroVM Exec API
-            System.out.printf("Executing in MicroVM \"%s\" (vmId: %s): %s%n",
-                name, vm.getStatus().getMicroVmId(), commandStr);
-            System.out.println("(Command execution not yet implemented - requires AWS Lambda MicroVM Exec API)");
-
-        } catch (KubernetesClientException e) {
-            if (e.getCode() == 0) {
-                System.err.println("Error: unable to connect to cluster");
-                System.exit(1);
-            }
-            System.err.printf("Error: %s%n", e.getMessage());
+        } catch (Exception e) {
+            System.err.printf("Error creating shell token for MicroVM '%s': %s%n", name, e.getMessage());
             System.exit(1);
         }
     }

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/DefaultMicroVMClient.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/DefaultMicroVMClient.java
@@ -99,6 +99,51 @@ public class DefaultMicroVMClient implements MicroVMClient {
                 .thenApply(r -> r.authToken());
     }
 
+    @Override
+    public CompletableFuture<Map<String, String>> createShellAuthToken(
+            String microvmId, int expirationMinutes) {
+        return sdk.createMicrovmShellAuthToken(CreateMicrovmShellAuthTokenRequest.builder()
+                .microvmIdentifier(microvmId)
+                .expirationInMinutes(expirationMinutes)
+                .build())
+                .thenApply(r -> r.authToken());
+    }
+
+    @Override
+    public CompletableFuture<java.util.List<ai.codriverlabs.microvm.aws.lambdamicrovms.model.MicrovmItem>> listMicroVMs(
+            String imageIdentifier) {
+        var builder = ListMicrovmsRequest.builder();
+        if (imageIdentifier != null) builder.imageIdentifier(imageIdentifier);
+        return sdk.listMicrovms(builder.build())
+                .thenApply(r -> r.items());
+    }
+
+    @Override
+    public CompletableFuture<Void> tagResource(String resourceArn, Map<String, String> tags) {
+        return sdk.tagResource(TagResourceRequest.builder()
+                .resource(resourceArn)
+                .tags(tags)
+                .build())
+                .thenApply(r -> null);
+    }
+
+    @Override
+    public CompletableFuture<Void> untagResource(String resourceArn, java.util.List<String> tagKeys) {
+        return sdk.untagResource(UntagResourceRequest.builder()
+                .resource(resourceArn)
+                .tagKeys(tagKeys)
+                .build())
+                .thenApply(r -> null);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, String>> listTags(String resourceArn) {
+        return sdk.listTags(ListTagsRequest.builder()
+                .resource(resourceArn)
+                .build())
+                .thenApply(r -> r.tags());
+    }
+
     @PreDestroy
     void close() {
         sdk.close();

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMClient.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMClient.java
@@ -1,5 +1,8 @@
 package ai.codriverlabs.microvm.operator.controller.aws;
 
+import ai.codriverlabs.microvm.aws.lambdamicrovms.model.MicrovmItem;
+
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -14,6 +17,9 @@ public interface MicroVMClient {
     /** Calls GetMicrovm — describes current state of a MicroVM. */
     CompletableFuture<DescribeMicroVMResponse> getMicroVM(String microvmId);
 
+    /** Calls ListMicrovms — lists MicroVMs, optionally filtered by image identifier. */
+    CompletableFuture<List<MicrovmItem>> listMicroVMs(String imageIdentifier);
+
     /** Calls SuspendMicrovm — suspends a running MicroVM (preserves state). */
     CompletableFuture<Void> suspendMicroVM(String microvmId);
 
@@ -23,14 +29,20 @@ public interface MicroVMClient {
     /** Calls TerminateMicrovm — terminates a MicroVM and releases all resources. */
     CompletableFuture<Void> terminateMicroVM(String microvmId);
 
-    /**
-     * Calls CreateMicrovmAuthToken — generates a short-lived JWE token for connecting
-     * to the MicroVM's HTTPS endpoint via the X-aws-proxy-auth header.
-     *
-     * @param microvmId          the MicroVM identifier
-     * @param expirationMinutes  token lifetime in minutes
-     * @param allPorts           if true, token allows access to all ports; otherwise port 8080 only
-     */
+    /** Calls CreateMicrovmAuthToken — short-lived JWE token for HTTPS endpoint access. */
     CompletableFuture<Map<String, String>> createAuthToken(
             String microvmId, int expirationMinutes, boolean allPorts);
+
+    /** Calls CreateMicrovmShellAuthToken — token for native shell (exec) access. */
+    CompletableFuture<Map<String, String>> createShellAuthToken(
+            String microvmId, int expirationMinutes);
+
+    /** Calls TagResource — applies tags to a MicroVM or image ARN. */
+    CompletableFuture<Void> tagResource(String resourceArn, Map<String, String> tags);
+
+    /** Calls UntagResource — removes tags from a resource. */
+    CompletableFuture<Void> untagResource(String resourceArn, List<String> tagKeys);
+
+    /** Calls ListTags — retrieves current tags on a resource. */
+    CompletableFuture<Map<String, String>> listTags(String resourceArn);
 }

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMImageClient.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMImageClient.java
@@ -82,6 +82,26 @@ public class MicroVMImageClient {
                 .build());
     }
 
+    public CompletableFuture<GetMicrovmImageBuildResponse> getLatestBuild(
+            String imageIdentifier, String imageVersion) {
+        return sdk.listMicrovmImageBuilds(ListMicrovmImageBuildsRequest.builder()
+                .imageIdentifier(imageIdentifier)
+                .imageVersion(imageVersion)
+                .maxResults(1)
+                .build())
+                .thenCompose(list -> {
+                    if (!list.hasItems() || list.items().isEmpty()) {
+                        return java.util.concurrent.CompletableFuture.completedFuture(null);
+                    }
+                    String buildId = list.items().get(0).buildId();
+                    return sdk.getMicrovmImageBuild(GetMicrovmImageBuildRequest.builder()
+                            .imageIdentifier(imageIdentifier)
+                            .imageVersion(imageVersion)
+                            .buildId(buildId)
+                            .build());
+                });
+    }
+
     @PreDestroy
     void close() { sdk.close(); }
 }

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMReconciler.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMReconciler.java
@@ -21,6 +21,7 @@ import org.jboss.logging.Logger;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -104,8 +105,9 @@ public class MicroVMReconciler implements Reconciler<MicroVM>, Cleaner<MicroVM> 
 
             return switch (driftResult) {
                 case DriftDetector.DriftResult.NoOp noOp -> {
-                    // Aligned - update status and schedule re-sync
+                    // Aligned - update status, sync tags, schedule re-sync
                     updateStatusFromAws(resource, awsState);
+                    syncTags(resource, status.getMicroVmId());
                     yield UpdateControl.patchStatus(resource).rescheduleAfter(RESYNC_PERIOD);
                 }
                 case DriftDetector.DriftResult.ActionRequired action -> {
@@ -360,6 +362,17 @@ public class MicroVMReconciler implements Reconciler<MicroVM>, Cleaner<MicroVM> 
                 throw awsEx;
             }
             throw new RuntimeException("Failed to describe MicroVM: " + e.getMessage(), e);
+        }
+    }
+
+    private void syncTags(MicroVM resource, String microvmId) {
+        if (microvmId == null) return;
+        Map<String, String> labels = resource.getMetadata().getLabels();
+        if (labels == null || labels.isEmpty()) return;
+        try {
+            microVMClient.tagResource(microvmId, labels).get(AWS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LOG.warnf("Failed to sync tags to MicroVM %s: %s", microvmId, e.getMessage());
         }
     }
 


### PR DESCRIPTION
## P2 — Tag propagation + ListMicrovms
- CR `.metadata.labels` synced to AWS tags on each aligned reconcile
- `MicroVMClient.listMicroVMs()` via ListMicrovms API

## P3 — Shell auth token + build info
- `kubectl microvm exec my-vm` prints WebSocket endpoint + shell token
- `MicroVMImageClient.getLatestBuild()` via ListMicrovmImageBuilds + GetMicrovmImageBuild

## Tests: 23, all passing