### PR TITLE
feat: complete API coverage — 24/24 APIs implemented

### DIFF
--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageBaseImagesCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageBaseImagesCommand.java
@@ -1,0 +1,66 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.aws.lambdamicrovms.LambdaMicrovmsClient;
+import ai.codriverlabs.microvm.aws.lambdamicrovms.model.*;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.List;
+
+/**
+ * kubectl microvm image base-images — list available Lambda-managed MicroVM base images.
+ *
+ * Usage:
+ *   kubectl microvm image base-images
+ *   kubectl microvm image base-images --region us-east-1
+ *   kubectl microvm image base-images --arn arn:aws:lambda:us-east-1:aws:microvm-image:al2023-1
+ */
+@Command(name = "base-images",
+        description = "List available Lambda-managed MicroVM base images",
+        mixinStandardHelpOptions = true)
+public class ImageBaseImagesCommand implements Runnable {
+
+    @Option(names = {"--region"}, defaultValue = "us-east-1", description = "AWS region (default: us-east-1)")
+    String region;
+
+    @Option(names = {"--arn"}, description = "Show versions for a specific base image ARN")
+    String imageArn;
+
+    @Override
+    public void run() {
+        try (LambdaMicrovmsClient awsClient = LambdaMicrovmsClient.builder()
+                .region(Region.of(region)).build()) {
+
+            if (imageArn != null) {
+                // List versions of a specific base image
+                List<ManagedMicrovmImageVersion> versions = awsClient
+                        .listManagedMicrovmImageVersions(
+                                ListManagedMicrovmImageVersionsRequest.builder()
+                                        .imageIdentifier(imageArn).build())
+                        .items();
+                System.out.printf("%-20s  %-30s  %s%n", "VERSION", "CREATED", "ARN");
+                for (var v : versions) {
+                    System.out.printf("%-20s  %-30s  %s%n",
+                            v.imageVersion() != null ? v.imageVersion() : "-",
+                            v.createdAt() != null ? v.createdAt().toString() : "-",
+                            v.imageArn() != null ? v.imageArn() : "-");
+                }
+            } else {
+                // List all managed base images
+                List<ManagedMicrovmImageSummary> images = awsClient
+                        .listManagedMicrovmImages(ListManagedMicrovmImagesRequest.builder().build())
+                        .items();
+                System.out.printf("%-60s  %s%n", "ARN", "CREATED");
+                for (var img : images) {
+                    System.out.printf("%-60s  %s%n",
+                            img.imageArn(),
+                            img.createdAt() != null ? img.createdAt().toString() : "-");
+                }
+            }
+        } catch (Exception e) {
+            System.err.printf("Error listing base images: %s%n", e.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageCommand.java
@@ -8,7 +8,9 @@ import picocli.CommandLine.Command;
         ImageListCommand.class,
         ImageDescribeCommand.class,
         ImageUpdateCommand.class,
-        ImageDeleteCommand.class
+        ImageDeleteCommand.class,
+        ImageBaseImagesCommand.class,
+        ImageVersionDeleteCommand.class
     },
     mixinStandardHelpOptions = true)
 public class ImageCommand {

--- a/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageVersionDeleteCommand.java
+++ b/operator-cli/src/main/java/ai/codriverlabs/microvm/operator/cli/commands/ImageVersionDeleteCommand.java
@@ -1,0 +1,69 @@
+package ai.codriverlabs.microvm.operator.cli.commands;
+
+import ai.codriverlabs.microvm.aws.lambdamicrovms.LambdaMicrovmsClient;
+import ai.codriverlabs.microvm.aws.lambdamicrovms.model.*;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMImage;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.inject.Inject;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import software.amazon.awssdk.regions.Region;
+
+/**
+ * kubectl microvm image version-delete — delete a specific MicroVM image version.
+ *
+ * Usage:
+ *   kubectl microvm image version-delete --name my-image --version 1.0
+ */
+@Command(name = "version-delete",
+        description = "Delete a specific MicroVM image version",
+        mixinStandardHelpOptions = true)
+public class ImageVersionDeleteCommand implements Runnable {
+
+    @Option(names = {"--name"}, required = true, description = "Name of the MicroVMImage CR")
+    String name;
+
+    @Option(names = {"--version"}, required = true, description = "Image version to delete (e.g. 1.0)")
+    String version;
+
+    @Option(names = {"-n", "--namespace"}, defaultValue = "default", description = "Namespace")
+    String namespace;
+
+    @Option(names = {"--region"}, description = "AWS region")
+    String region;
+
+    @Inject
+    KubernetesClient client;
+
+    @Override
+    public void run() {
+        MicroVMImage image = client.resources(MicroVMImage.class)
+                .inNamespace(namespace).withName(name).get();
+        if (image == null) {
+            System.err.printf("MicroVMImage '%s' not found in namespace '%s'%n", name, namespace);
+            System.exit(1);
+            return;
+        }
+        if (image.getStatus() == null || image.getStatus().getImageArn() == null) {
+            System.err.printf("MicroVMImage '%s' has no imageArn in status%n", name);
+            System.exit(1);
+            return;
+        }
+
+        String imageArn = image.getStatus().getImageArn();
+        String awsRegion = region != null ? region
+                : (image.getSpec().getRegion() != null ? image.getSpec().getRegion() : "us-east-1");
+
+        try (LambdaMicrovmsClient awsClient = LambdaMicrovmsClient.builder()
+                .region(Region.of(awsRegion)).build()) {
+            awsClient.deleteMicrovmImageVersion(DeleteMicrovmImageVersionRequest.builder()
+                    .imageIdentifier(imageArn)
+                    .imageVersion(version)
+                    .build());
+            System.out.printf("microvm-image/%s version %s deleted%n", name, version);
+        } catch (Exception e) {
+            System.err.printf("Error deleting image version: %s%n", e.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMImageClient.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMImageClient.java
@@ -82,6 +82,28 @@ public class MicroVMImageClient {
                 .build());
     }
 
+    public CompletableFuture<DeleteMicrovmImageVersionResponse> deleteVersion(
+            String imageIdentifier, String imageVersion) {
+        return sdk.deleteMicrovmImageVersion(DeleteMicrovmImageVersionRequest.builder()
+                .imageIdentifier(imageIdentifier)
+                .imageVersion(imageVersion)
+                .build());
+    }
+
+    public CompletableFuture<List<ManagedMicrovmImageSummary>> listManagedBaseImages() {
+        return sdk.listManagedMicrovmImages(ListManagedMicrovmImagesRequest.builder().build())
+                .thenApply(r -> r.items());
+    }
+
+    public CompletableFuture<List<ManagedMicrovmImageVersion>> listManagedBaseImageVersions(
+            String imageArn) {
+        return sdk.listManagedMicrovmImageVersions(
+                ListManagedMicrovmImageVersionsRequest.builder()
+                        .imageIdentifier(imageArn)
+                        .build())
+                .thenApply(r -> r.items());
+    }
+
     public CompletableFuture<GetMicrovmImageBuildResponse> getLatestBuild(
             String imageIdentifier, String imageVersion) {
         return sdk.listMicrovmImageBuilds(ListMicrovmImageBuildsRequest.builder()

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMReconciler.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMReconciler.java
@@ -368,9 +368,24 @@ public class MicroVMReconciler implements Reconciler<MicroVM>, Cleaner<MicroVM> 
     private void syncTags(MicroVM resource, String microvmId) {
         if (microvmId == null) return;
         Map<String, String> labels = resource.getMetadata().getLabels();
-        if (labels == null || labels.isEmpty()) return;
         try {
-            microVMClient.tagResource(microvmId, labels).get(AWS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            // Fetch current AWS tags
+            Map<String, String> awsTags = microVMClient.listTags(microvmId).get(AWS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            // Add/update labels that changed
+            if (labels != null && !labels.isEmpty()) {
+                microVMClient.tagResource(microvmId, labels).get(AWS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            }
+
+            // Remove tags whose keys no longer exist in labels
+            if (awsTags != null) {
+                java.util.List<String> toRemove = awsTags.keySet().stream()
+                        .filter(k -> labels == null || !labels.containsKey(k))
+                        .collect(java.util.stream.Collectors.toList());
+                if (!toRemove.isEmpty()) {
+                    microVMClient.untagResource(microvmId, toRemove).get(AWS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                }
+            }
         } catch (Exception e) {
             LOG.warnf("Failed to sync tags to MicroVM %s: %s", microvmId, e.getMessage());
         }


### PR DESCRIPTION
Closes all remaining API gaps so kubectl-microvm is fully independent of the AWS CLI.

- `kubectl microvm image base-images` — ListManagedMicrovmImages
- `kubectl microvm image base-images --arn X` — ListManagedMicrovmImageVersions  
- `kubectl microvm image version-delete --name X --version 1.0` — DeleteMicrovmImageVersion
- Tag removal wired: UntagResource called when CR labels removed

Tests: 23, all passing