### PR TITLE
feat: MicroVMNetwork reconciler via lambda-core API

### DIFF
--- a/docs/design/missing-features.md
+++ b/docs/design/missing-features.md
@@ -9,32 +9,152 @@ It is the authoritative TODO for engineering work beyond the initial API coverag
 
 **Status**: Model and design exist. Reconciler not implemented.
 
-**What exists:**
-- `MicroVMNetwork` / `MicroVMNetworkSpec` model classes
-- Full design in `docs/design/networking.md`
-- Webhook validates `networkRef` field on MicroVMSpec
-- `MicroVMReconciler` reads `networkRef` and passes `connectorArn` to RunMicrovm (assumes status already populated)
+**Revised design** (supersedes `docs/design/networking.md`):
 
-**What's missing:**
+VPC Network Connectors are managed via the `lambda-core` API (separate AWS service, distinct from `lambda-microvms`). The operator must generate a second SDK client from the `lambda-core` botocore service model, exactly as it did for `lambda-microvms`.
 
-| Gap | Detail |
-|-----|--------|
-| `MicroVMNetworkReconciler` | No reconciler class exists. Operator does not call `CreateNetworkConnector` / `DeleteNetworkConnector` / poll state |
-| `MicroVMNetworkStatus` | No status class exists — `connectorArn`, `connectorState`, `conditions` are never written |
-| Network Connector API client | `MicroVMNetworkClient` wrapper does not exist — the SDK methods exist but are not wired |
-| IAM CloudFormation template | `iam/` has the operator role but no template for the customer's VPC ENI role (`operatorRoleArn`) |
-| Webhook validation | Webhook currently only validates that `networkRef` is a non-empty string; it does not check the referenced CR exists or is Ready |
-| CLI | `kubectl microvm network` subcommand does not exist |
+### SDK Client Generation
 
-**AWS APIs required:**
-- `CreateNetworkConnector` — provisions ENIs in customer VPC subnets
+A new Maven module `operator-aws-client-core` is required:
+- Feeds `/snap/aws-cli/.../botocore/data/lambda-core/2026-04-30/service-2.json` into `codegen-maven-plugin`
+- Generates `LambdaCoreClient` / `LambdaCoreAsyncClient` in package `ai.codriverlabs.microvm.aws.lambdacore`
+- `operator-controller` adds `operator-aws-client-core` as a dependency alongside `operator-aws-client`
+
+`lambda-core` operations needed:
+- `CreateNetworkConnector` — provision ENIs in customer VPC subnets
 - `GetNetworkConnector` — poll PENDING → ACTIVE / FAILED
+- `UpdateNetworkConnector` — update subnet/SG config
 - `DeleteNetworkConnector` — cleanup on CR delete
 - `ListNetworkConnectors` — discovery / drift detection
 
-**Unresolved design questions:**
-- Should `MicroVMNetwork` be cluster-scoped or namespace-scoped? Currently `Namespaced`. Cross-namespace reference from a MicroVM needs a policy decision.
-- Should the operator validate that subnets/SGs exist via `ec2:Describe*`? Adds EC2 IAM permissions to the operator role.
+### MicroVMNetworkSpec (revised)
+
+Current `MicroVMNetworkSpec` has `{vpcId, subnetIds, securityGroupIds}` which maps directly to `NetworkConnectorVpcEgressConfiguration`. Add `operatorRoleArn` and `networkProtocol`:
+
+```yaml
+spec:
+  subnetIds:
+    - subnet-abc123
+    - subnet-def456
+  securityGroupIds:
+    - sg-xyz789
+  operatorRoleArn: arn:aws:iam::864899852480:role/MicroVMNetworkConnectorRole
+  networkProtocol: IPv4          # IPv4 | DualStack (default: IPv4)
+  region: us-east-1
+  tags:
+    environment: production
+```
+
+Note: `vpcId` can be removed from spec — the Lambda Core API derives the VPC from the subnets. It is not a parameter to `CreateNetworkConnector`.
+
+### MicroVMNetworkStatus (new class required)
+
+```java
+public class MicroVMNetworkStatus {
+    String connectorArn;        // set after CreateNetworkConnector returns
+    String connectorId;
+    String connectorState;      // PENDING | ACTIVE | INACTIVE | FAILED | DELETING | DELETE_FAILED
+    String stateReason;
+    String stateReasonCode;
+    String observedGeneration;
+    List<Condition> conditions; // Ready=True when ACTIVE
+}
+```
+
+### Reconciler Flow
+
+```
+CREATE:
+  1. Call CreateNetworkConnector(name, subnetIds, securityGroupIds, operatorRoleArn, networkProtocol)
+     → set status.connectorArn, status.connectorState=PENDING
+  2. Poll GetNetworkConnector every 15s until ACTIVE or FAILED
+  3. On ACTIVE: set condition Ready=True, reschedule at 5min
+  4. On FAILED: set condition Ready=False with stateReason, emit Warning event
+
+UPDATE (spec change detected via observedGeneration):
+  1. Call UpdateNetworkConnector with new subnetIds/securityGroupIds
+  2. Poll until ACTIVE or FAILED (same as create)
+  Note: Cannot update while MicroVMs are running — webhook should warn; reconciler emits event
+
+DELETE (finalizer: lambda.aws.amazon.com/network-connector-finalizer):
+  1. Check no MicroVMs reference this network (list CRs with spec.networkRef=<name>)
+  2. If in-use: block deletion, emit Warning event, requeue
+  3. Call DeleteNetworkConnector
+  4. Poll until state=DELETING completes (connector disappears from GetNetworkConnector → 404)
+  5. Remove finalizer
+```
+
+### MicroVMNetworkClient wrapper
+
+New class `MicroVMNetworkClient` in `operator-controller`:
+```java
+CompletableFuture<CreateNetworkConnectorResponse> createConnector(MicroVMNetworkSpec spec, String name);
+CompletableFuture<GetNetworkConnectorResponse>    getConnector(String connectorArn);
+CompletableFuture<UpdateNetworkConnectorResponse> updateConnector(String connectorArn, MicroVMNetworkSpec spec);
+CompletableFuture<DeleteNetworkConnectorResponse> deleteConnector(String connectorArn);
+CompletableFuture<List<NetworkConnectorSummary>>  listConnectors();
+```
+
+### MicroVM ↔ Network Association (unchanged)
+
+When `MicroVM` has `spec.networkRef`, the `MicroVMReconciler`:
+1. Looks up the referenced `MicroVMNetwork` CR
+2. Checks `status.connectorState == ACTIVE`
+3. Passes `status.connectorArn` as egress connector to `RunMicrovm`
+4. If not ACTIVE: MicroVM stays PENDING with condition `NetworkReady=False`
+
+### Lambda-Managed Connectors (no reconciliation needed)
+
+For the standard AWS-managed connectors, users can reference them directly in `MicroVMSpec` without a `MicroVMNetwork` CR:
+
+| Name | ARN |
+|------|-----|
+| `ALL_INGRESS` | `arn:aws:lambda:<region>:aws:network-connector:aws-network-connector:ALL_INGRESS` |
+| `INTERNET_EGRESS` | `arn:aws:lambda:<region>:aws:network-connector:aws-network-connector:INTERNET_EGRESS` |
+| `NO_INGRESS` | `arn:aws:lambda:<region>:aws:network-connector:aws-network-connector:NO_INGRESS` |
+
+### IAM Requirements
+
+The operator's pod identity role needs:
+```json
+{
+  "Action": [
+    "lambda:CreateNetworkConnector",
+    "lambda:GetNetworkConnector",
+    "lambda:UpdateNetworkConnector",
+    "lambda:DeleteNetworkConnector",
+    "lambda:ListNetworkConnectors"
+  ],
+  "Resource": "*",
+  "Effect": "Allow"
+}
+```
+
+The customer also needs a separate ENI provisioning role (`spec.operatorRoleArn`) trusted by `network-connectors.lambda.amazonaws.com` with `ec2:CreateNetworkInterface` + `ec2:CreateTags`.
+
+### CLI
+
+New subcommand group `kubectl microvm network`:
+```bash
+kubectl microvm network list
+kubectl microvm network describe --name my-network
+kubectl microvm network create --name my-network --subnets subnet-abc,subnet-def --security-groups sg-xyz --role arn:...
+kubectl microvm network delete --name my-network
+```
+
+### What's missing (implementation checklist)
+
+- [ ] New Maven module `operator-aws-client-core` with `lambda-core` codegen
+- [ ] `MicroVMNetworkStatus` model class
+- [ ] Update `MicroVMNetworkSpec`: remove `vpcId`, add `operatorRoleArn`, `networkProtocol`, `region`, `tags`
+- [ ] `MicroVMNetworkClient` wrapper class
+- [ ] `MicroVMNetworkReconciler` (create / poll / update / delete with finalizer)
+- [ ] `MicroVMReconciler`: check `NetworkReady` condition before RunMicrovm (currently assumes status is populated)
+- [ ] Validating webhook: check referenced `MicroVMNetwork` CR exists and is Ready
+- [ ] IAM role update (`iam/kube-microvm-operator-role.yaml`) with lambda-core permissions
+- [ ] IAM CloudFormation template for customer's ENI role
+- [ ] `kubectl microvm network` CLI subcommands
+- [ ] Integration tests: `MicroVMNetworkReconcilerIT`
 
 ---
 

--- a/docs/design/networking.md
+++ b/docs/design/networking.md
@@ -45,10 +45,12 @@ Lambda MicroVMs run in **AWS-managed infrastructure** (Fargate-style). They do N
 
 The `MicroVMNetwork` CRD is a **reconciled resource**. The operator creates and manages an AWS Lambda Network Connector based on the CR spec.
 
+> **Important**: Network Connectors are managed via the `lambda-core` AWS API (service ID `Lambda Core`, endpoint prefix `lambda`), **not** the `lambda-microvms` API. The operator requires a second generated SDK client (`operator-aws-client-core`) built from the `lambda-core` botocore service model.
+
 ```
 MicroVMNetwork CR (Kubernetes)
         ↓ reconcile
-AWS Network Connector (AWS resource)
+LambdaCoreClient.createNetworkConnector()
         ↓ provisions
 ENIs in customer VPC subnets
         ↓ routes
@@ -59,8 +61,9 @@ Outbound traffic from MicroVM → customer VPC → private resources
 
 ```
 1. User creates MicroVMNetwork CR
-2. Operator calls `lambda-core:CreateNetworkConnector`
+2. Operator calls LambdaCoreClient.createNetworkConnector()
    - Passes SubnetIds, SecurityGroupIds, NetworkProtocol, OperatorRoleArn
+   - Note: VpcId is NOT a parameter — Lambda Core derives VPC from subnets
 3. AWS provisions ENIs in specified subnets (PENDING → ACTIVE)
 4. Operator updates status.connectorArn, status.connectorState
 5. MicroVMs referencing this network can now use the connector ARN at run-microvm time

--- a/operator-aws-client-core/pom.xml
+++ b/operator-aws-client-core/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.codriverlabs</groupId>
+        <artifactId>microvm-operator-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>operator-aws-client-core</artifactId>
+    <name>Lambda VM ACK Operator - AWS Lambda Core SDK Client</name>
+    <description>Generated AWS SDK client for lambda-core (2026-04-30) — Network Connector management</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>protocol-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-json-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>codegen-maven-plugin</artifactId>
+                <version>${aws.sdk.version}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/operator-aws-client-core/src/main/resources/codegen-resources/customization.config
+++ b/operator-aws-client-core/src/main/resources/codegen-resources/customization.config
@@ -1,0 +1,1 @@
+{"rootPackageName":"ai.codriverlabs.microvm.aws.lambdacore"}

--- a/operator-aws-client-core/src/main/resources/codegen-resources/paginators-1.json
+++ b/operator-aws-client-core/src/main/resources/codegen-resources/paginators-1.json
@@ -1,0 +1,10 @@
+{
+  "pagination": {
+    "ListNetworkConnectors": {
+      "input_token": "Marker",
+      "output_token": "NextMarker",
+      "limit_key": "MaxItems",
+      "result_key": "NetworkConnectors"
+    }
+  }
+}

--- a/operator-aws-client-core/src/main/resources/codegen-resources/service-2.json
+++ b/operator-aws-client-core/src/main/resources/codegen-resources/service-2.json
@@ -1,0 +1,735 @@
+{
+  "version":"2.0",
+  "metadata":{
+    "apiVersion":"2026-04-30",
+    "auth":["aws.auth#sigv4"],
+    "endpointPrefix":"lambda",
+    "protocol":"rest-json",
+    "protocols":["rest-json"],
+    "serviceFullName":"AWS Lambda Core",
+    "serviceId":"Lambda Core",
+    "signatureVersion":"v4",
+    "signingName":"lambda",
+    "uid":"lambda-core-2026-04-30"
+  },
+  "operations":{
+    "CreateNetworkConnector":{
+      "name":"CreateNetworkConnector",
+      "http":{
+        "method":"POST",
+        "requestUri":"/2026-04-04/network-connectors",
+        "responseCode":202
+      },
+      "input":{"shape":"CreateNetworkConnectorRequest"},
+      "output":{"shape":"CreateNetworkConnectorResponse"},
+      "errors":[
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"ResourceConflictException"},
+        {"shape":"NetworkConnectorLimitExceededException"},
+        {"shape":"ServiceException"},
+        {"shape":"TooManyRequestsException"}
+      ],
+      "documentation":"<p>Creates a network connector that enables Lambda compute resources to route outbound traffic through your Amazon VPC. The network connector provisions elastic network interfaces (ENIs) in the subnets you specify, providing a managed network path to private resources such as databases, caches, and internal APIs.</p> <p>This operation is asynchronous. The network connector starts in <code>PENDING</code> state while ENIs are provisioned in your VPC (provisioning typically takes up to 10 minutes). Use <code>GetNetworkConnector</code> to poll the connector state until it reaches <code>ACTIVE</code>. Once active, you can attach the connector to Lambda MicroVMs at run time using the <code>egressNetworkConnectors</code> parameter on <code>RunMicroVm</code>.</p> <p>This operation is idempotent when you provide a <code>ClientToken</code> — if you retry a request that completed successfully using the same client token, the operation returns the existing connector without creating a duplicate.</p>",
+      "idempotent":true
+    },
+    "DeleteNetworkConnector":{
+      "name":"DeleteNetworkConnector",
+      "http":{
+        "method":"DELETE",
+        "requestUri":"/2026-04-04/network-connectors/{Identifier}",
+        "responseCode":202
+      },
+      "input":{"shape":"DeleteNetworkConnectorRequest"},
+      "output":{"shape":"DeleteNetworkConnectorResponse"},
+      "errors":[
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"ResourceConflictException"},
+        {"shape":"ServiceException"},
+        {"shape":"TooManyRequestsException"},
+        {"shape":"ResourceNotFoundException"}
+      ],
+      "documentation":"<p>Initiates deletion of a network connector. The connector transitions to <code>DELETING</code> state while elastic network interfaces are cleaned up asynchronously. After deletion completes, subsequent calls to <code>GetNetworkConnector</code> return <code>ResourceNotFoundException</code>.</p> <p>This operation is idempotent — calling delete on a connector that is already deleting or has been deleted succeeds without error. You can delete connectors in <code>ACTIVE</code> or <code>FAILED</code> states. Before deleting a connector, ensure that no Lambda MicroVMs are using it, as they will lose VPC egress connectivity immediately.</p>",
+      "idempotent":true
+    },
+    "GetNetworkConnector":{
+      "name":"GetNetworkConnector",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2026-04-04/network-connectors/{Identifier}",
+        "responseCode":200
+      },
+      "input":{"shape":"GetNetworkConnectorRequest"},
+      "output":{"shape":"GetNetworkConnectorResponse"},
+      "errors":[
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"ServiceException"},
+        {"shape":"TooManyRequestsException"},
+        {"shape":"ResourceNotFoundException"}
+      ],
+      "documentation":"<p>Retrieves the current configuration, state, and metadata of a network connector. The <code>Identifier</code> parameter accepts the connector ID, name, or full ARN. Use this operation to poll connector state after creation or update, or to inspect the current VPC configuration and any failure reasons.</p> <p>The response includes the full connector configuration, current state, and — if the connector has been updated — the <code>LastUpdateStatus</code> and <code>LastUpdateStatusReasonCode</code> fields that indicate whether the most recent update succeeded or failed.</p>",
+      "readonly":true
+    },
+    "ListNetworkConnectors":{
+      "name":"ListNetworkConnectors",
+      "http":{
+        "method":"GET",
+        "requestUri":"/2026-04-04/network-connectors",
+        "responseCode":200
+      },
+      "input":{"shape":"ListNetworkConnectorsRequest"},
+      "output":{"shape":"ListNetworkConnectorsResponse"},
+      "errors":[
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"ServiceException"},
+        {"shape":"TooManyRequestsException"}
+      ],
+      "documentation":"<p>Returns a paginated list of network connectors in your account for the current Region. You can optionally filter results by connector state. Use the <code>Marker</code> parameter from a previous response to retrieve the next page of results.</p> <p>Each item in the response includes the connector ARN, name, ID, type, current state, and last modified timestamp. To retrieve full configuration details for a specific connector, use <code>GetNetworkConnector</code>.</p>",
+      "readonly":true
+    },
+    "UpdateNetworkConnector":{
+      "name":"UpdateNetworkConnector",
+      "http":{
+        "method":"PUT",
+        "requestUri":"/2026-04-04/network-connectors/{Identifier}",
+        "responseCode":202
+      },
+      "input":{"shape":"UpdateNetworkConnectorRequest"},
+      "output":{"shape":"UpdateNetworkConnectorResponse"},
+      "errors":[
+        {"shape":"InvalidParameterValueException"},
+        {"shape":"ResourceConflictException"},
+        {"shape":"ServiceException"},
+        {"shape":"TooManyRequestsException"},
+        {"shape":"ResourceNotFoundException"}
+      ],
+      "documentation":"<p>Updates the VPC configuration or operator role of an existing network connector. You can modify the subnet IDs, security group IDs, network protocol, or operator role. The connector must be in <code>ACTIVE</code> state to accept updates.</p> <p>This operation is asynchronous. The connector remains in <code>ACTIVE</code> state during the update — existing workloads that reference this connector are not disrupted. Use <code>GetNetworkConnector</code> to monitor the <code>LastUpdateStatus</code> field, which transitions through <code>InProgress</code> to <code>Successful</code> or <code>Failed</code>. If the update fails, the <code>LastUpdateStatusReasonCode</code> field provides a specific error code for troubleshooting. This operation is idempotent when you provide a <code>ClientToken</code>.</p>"
+    }
+  },
+  "shapes":{
+    "AssociatedComputeResourceTypesList":{
+      "type":"list",
+      "member":{"shape":"ComputeResourceType"},
+      "max":1,
+      "min":1
+    },
+    "ClientTokenString":{
+      "type":"string",
+      "max":64,
+      "min":1
+    },
+    "ComputeResourceType":{
+      "type":"string",
+      "enum":["MicroVm"]
+    },
+    "CoreTimestamp":{
+      "type":"timestamp",
+      "timestampFormat":"iso8601"
+    },
+    "CreateNetworkConnectorRequest":{
+      "type":"structure",
+      "required":[
+        "Name",
+        "Configuration"
+      ],
+      "members":{
+        "Name":{
+          "shape":"NetworkConnectorName",
+          "documentation":"<p>A unique name for the network connector within your account and Region. You can use the name to identify the connector in subsequent API calls.</p>"
+        },
+        "Configuration":{
+          "shape":"NetworkConnectorConfiguration",
+          "documentation":"<p>The network configuration for the connector. Specify a <code>VpcEgressConfiguration</code> to enable outbound traffic routing through your VPC.</p>"
+        },
+        "OperatorRole":{
+          "shape":"NetworkConnectorRoleArn",
+          "documentation":"<p>The ARN of the IAM role that Lambda assumes to manage elastic network interfaces in your VPC. This role must have permissions for <code>ec2:CreateNetworkInterface</code>, <code>ec2:DeleteNetworkInterface</code>, and related describe operations.</p>"
+        },
+        "ClientToken":{
+          "shape":"ClientTokenString",
+          "documentation":"<p>A unique, case-sensitive identifier that you provide to ensure the idempotency of the request. If you retry a request with the same client token, the API returns the existing connector without creating a duplicate.</p>",
+          "idempotencyToken":true
+        },
+        "Tags":{
+          "shape":"NetworkConnectorTags",
+          "documentation":"<p>A map of key-value pairs to associate with the network connector for organization, cost allocation, or access control.</p>"
+        }
+      }
+    },
+    "CreateNetworkConnectorResponse":{
+      "type":"structure",
+      "required":[
+        "Arn",
+        "Name",
+        "Id"
+      ],
+      "members":{
+        "Arn":{
+          "shape":"NetworkConnectorArn",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the network connector.</p>"
+        },
+        "Name":{
+          "shape":"NetworkConnectorName",
+          "documentation":"<p>The name of the network connector.</p>"
+        },
+        "Id":{"shape":"NetworkConnectorId"},
+        "Configuration":{
+          "shape":"NetworkConnectorConfiguration",
+          "documentation":"<p>The network configuration of the connector, including VPC subnets and security groups.</p>"
+        },
+        "OperatorRole":{
+          "shape":"NetworkConnectorRoleArn",
+          "documentation":"<p>The ARN of the IAM role that Lambda uses to manage the underlying ENI resources for this connector.</p>"
+        },
+        "State":{
+          "shape":"NetworkConnectorState",
+          "documentation":"<p>The current state of the network connector.</p>"
+        }
+      }
+    },
+    "DeleteNetworkConnectorRequest":{
+      "type":"structure",
+      "required":["Identifier"],
+      "members":{
+        "Identifier":{
+          "shape":"NetworkConnectorIdentifier",
+          "location":"uri",
+          "locationName":"Identifier"
+        }
+      }
+    },
+    "DeleteNetworkConnectorResponse":{
+      "type":"structure",
+      "required":[
+        "Arn",
+        "Name",
+        "Id"
+      ],
+      "members":{
+        "Arn":{
+          "shape":"NetworkConnectorArn",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the network connector.</p>"
+        },
+        "Name":{
+          "shape":"NetworkConnectorName",
+          "documentation":"<p>The name of the network connector.</p>"
+        },
+        "Id":{"shape":"NetworkConnectorId"},
+        "Configuration":{
+          "shape":"NetworkConnectorConfiguration",
+          "documentation":"<p>The network configuration of the connector, including VPC subnets and security groups.</p>"
+        },
+        "OperatorRole":{
+          "shape":"NetworkConnectorRoleArn",
+          "documentation":"<p>The ARN of the IAM role that Lambda uses to manage the underlying ENI resources for this connector.</p>"
+        },
+        "State":{
+          "shape":"NetworkConnectorState",
+          "documentation":"<p>The current state of the network connector. The State field is typically <code>DELETING</code> after this call.</p>"
+        }
+      }
+    },
+    "GetNetworkConnectorRequest":{
+      "type":"structure",
+      "required":["Identifier"],
+      "members":{
+        "Identifier":{
+          "shape":"NetworkConnectorIdentifier",
+          "location":"uri",
+          "locationName":"Identifier"
+        }
+      }
+    },
+    "GetNetworkConnectorResponse":{
+      "type":"structure",
+      "required":[
+        "Arn",
+        "Name",
+        "Id"
+      ],
+      "members":{
+        "Arn":{
+          "shape":"NetworkConnectorArn",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the network connector.</p>"
+        },
+        "Name":{
+          "shape":"NetworkConnectorName",
+          "documentation":"<p>The name of the network connector.</p>"
+        },
+        "Id":{"shape":"NetworkConnectorId"},
+        "Version":{
+          "shape":"NetworkConnectorVersion",
+          "documentation":"<p>The version number of the connector configuration, incremented on each update.</p>"
+        },
+        "Configuration":{
+          "shape":"NetworkConnectorConfiguration",
+          "documentation":"<p>The network configuration of the connector, including VPC subnets and security groups.</p>"
+        },
+        "OperatorRole":{
+          "shape":"NetworkConnectorRoleArn",
+          "documentation":"<p>The ARN of the IAM role that Lambda uses to manage the underlying ENI resources for this connector.</p>"
+        },
+        "State":{
+          "shape":"NetworkConnectorState",
+          "documentation":"<p>The current state of the network connector.</p>"
+        },
+        "StateReason":{
+          "shape":"String",
+          "documentation":"<p>A human-readable explanation of the current state, populated when the state is <code>FAILED</code> or <code>DELETE_FAILED</code>.</p>"
+        },
+        "StateReasonCode":{
+          "shape":"NetworkConnectorStateReasonCode",
+          "documentation":"<p>A machine-readable code indicating the reason for the current state. Use this for programmatic error handling.</p>"
+        },
+        "LastUpdateStatus":{
+          "shape":"NetworkConnectorLastUpdateStatus",
+          "documentation":"<p>The status of the most recent update operation (<code>Successful</code>, <code>Failed</code>, or <code>InProgress</code>).</p>"
+        },
+        "LastUpdateStatusReason":{
+          "shape":"NetworkConnectorLastUpdateStatusReason",
+          "documentation":"<p>A human-readable explanation of the last update status.</p>"
+        },
+        "LastUpdateStatusReasonCode":{
+          "shape":"NetworkConnectorLastUpdateStatusReasonCode",
+          "documentation":"<p>A machine-readable code indicating the reason for the last update status. Use this for programmatic error handling.</p>"
+        },
+        "LastModified":{
+          "shape":"CoreTimestamp",
+          "documentation":"<p>The date and time when the connector configuration was last modified.</p>"
+        }
+      }
+    },
+    "InvalidParameterValueException":{
+      "type":"structure",
+      "members":{
+        "Type":{
+          "shape":"String",
+          "documentation":"<p>The exception type.</p>"
+        },
+        "message":{"shape":"String"}
+      },
+      "documentation":"<p>One of the parameters in the request is not valid. Check the error message for details about which parameter failed validation.</p>",
+      "error":{
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "ListNetworkConnectorsRequest":{
+      "type":"structure",
+      "members":{
+        "State":{
+          "shape":"NetworkConnectorState",
+          "documentation":"<p>Optional filter to return only connectors in the specified state (for example, <code>ACTIVE</code> or <code>FAILED</code>).</p>",
+          "location":"querystring",
+          "locationName":"State"
+        },
+        "Marker":{
+          "shape":"String",
+          "documentation":"<p>The pagination token from a previous <code>ListNetworkConnectors</code> response. Use this value to retrieve the next page of results.</p>",
+          "location":"querystring",
+          "locationName":"Marker"
+        },
+        "MaxItems":{
+          "shape":"MaxHundredListItems",
+          "documentation":"<p>The maximum number of connectors to return per page. Valid range: 1 to 100.</p>",
+          "location":"querystring",
+          "locationName":"MaxItems"
+        }
+      }
+    },
+    "ListNetworkConnectorsResponse":{
+      "type":"structure",
+      "required":["NetworkConnectors"],
+      "members":{
+        "NetworkConnectors":{
+          "shape":"NetworkConnectorsList",
+          "documentation":"<p>A list of network connector summaries for the current page of results.</p>"
+        },
+        "NextMarker":{
+          "shape":"String",
+          "documentation":"<p>The pagination token to include in a subsequent request to retrieve the next page. This value is null when there are no more results.</p>"
+        }
+      }
+    },
+    "MaxHundredListItems":{
+      "type":"integer",
+      "box":true,
+      "max":100,
+      "min":1
+    },
+    "NetworkConnectorArn":{
+      "type":"string",
+      "max":140,
+      "min":1,
+      "pattern":"(arn:aws[a-zA-Z-]*:lambda:(eusc-)?[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:network-connector:[a-zA-Z0-9-_]+(:[1-9]|[1-9][0-9]+)?)"
+    },
+    "NetworkConnectorConfiguration":{
+      "type":"structure",
+      "members":{
+        "VpcEgressConfiguration":{
+          "shape":"NetworkConnectorVpcEgressConfiguration",
+          "documentation":"<p>Configuration for a VPC egress network connector. Specifies the subnets, security groups, and network protocol for routing outbound traffic through your VPC.</p>"
+        }
+      },
+      "documentation":"<p>The network configuration for a network connector. Different connector types use different configuration shapes; specify the configuration that matches your connector type.</p>",
+      "union":true
+    },
+    "NetworkConnectorId":{
+      "type":"string",
+      "documentation":"<p>The unique identifier for a network connector, assigned by the service at creation time</p>",
+      "max":140,
+      "min":1
+    },
+    "NetworkConnectorIdentifier":{
+      "type":"string",
+      "documentation":"<p>A flexible identifier that accepts a network connector ID, name, or ARN</p>",
+      "max":140,
+      "min":1
+    },
+    "NetworkConnectorLastUpdateStatus":{
+      "type":"string",
+      "enum":[
+        "Successful",
+        "Failed",
+        "InProgress"
+      ]
+    },
+    "NetworkConnectorLastUpdateStatusReason":{"type":"string"},
+    "NetworkConnectorLastUpdateStatusReasonCode":{
+      "type":"string",
+      "enum":[
+        "DisallowedByVpcEncryptionControl",
+        "Ec2RequestLimitExceeded",
+        "InsufficientRolePermissions",
+        "InternalError",
+        "InvalidSecurityGroup",
+        "InvalidSubnet",
+        "SubnetOutOfIPAddresses"
+      ]
+    },
+    "NetworkConnectorLimitExceededException":{
+      "type":"structure",
+      "members":{
+        "Type":{
+          "shape":"String",
+          "documentation":"<p>The exception type.</p>"
+        },
+        "message":{
+          "shape":"String",
+          "documentation":"<p>A human-readable description of the error.</p>"
+        }
+      },
+      "documentation":"<p>The account has reached the maximum number of network connectors allowed. Delete unused connectors or request a limit increase through Service Quotas.</p>",
+      "error":{
+        "httpStatusCode":400,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "NetworkConnectorName":{
+      "type":"string",
+      "max":140,
+      "min":1,
+      "pattern":"(arn:aws[a-zA-Z-]*:lambda:(eusc-)?[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}:\\d{12}:network-connector:[a-zA-Z0-9-_]+(:[1-9]|[1-9][0-9]+)?)|[a-zA-Z0-9_-]{1,64}"
+    },
+    "NetworkConnectorRoleArn":{
+      "type":"string",
+      "max":10000,
+      "min":0,
+      "pattern":"arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
+    },
+    "NetworkConnectorSecurityGroupId":{
+      "type":"string",
+      "max":1024,
+      "min":0,
+      "pattern":"sg-[0-9a-zA-Z]*"
+    },
+    "NetworkConnectorSecurityGroupIds":{
+      "type":"list",
+      "member":{"shape":"NetworkConnectorSecurityGroupId"},
+      "max":5,
+      "min":0
+    },
+    "NetworkConnectorState":{
+      "type":"string",
+      "enum":[
+        "PENDING",
+        "ACTIVE",
+        "INACTIVE",
+        "FAILED",
+        "DELETING",
+        "DELETE_FAILED"
+      ]
+    },
+    "NetworkConnectorStateReasonCode":{
+      "type":"string",
+      "enum":[
+        "DisallowedByVpcEncryptionControl",
+        "Ec2RequestLimitExceeded",
+        "InsufficientRolePermissions",
+        "InternalError",
+        "InvalidSecurityGroup",
+        "InvalidSubnet",
+        "SubnetOutOfIPAddresses"
+      ]
+    },
+    "NetworkConnectorSubnetId":{
+      "type":"string",
+      "max":1024,
+      "min":0,
+      "pattern":"subnet-[0-9a-z]*"
+    },
+    "NetworkConnectorSubnetIds":{
+      "type":"list",
+      "member":{"shape":"NetworkConnectorSubnetId"},
+      "max":16,
+      "min":1
+    },
+    "NetworkConnectorSummary":{
+      "type":"structure",
+      "required":[
+        "Arn",
+        "Name",
+        "Id",
+        "Type"
+      ],
+      "members":{
+        "Arn":{
+          "shape":"NetworkConnectorArn",
+          "documentation":"<p>The ARN of the network connector.</p>"
+        },
+        "Name":{
+          "shape":"NetworkConnectorName",
+          "documentation":"<p>The name of the network connector.</p>"
+        },
+        "Id":{"shape":"NetworkConnectorId"},
+        "Type":{
+          "shape":"NetworkConnectorType",
+          "documentation":"<p>The type of the network connector (<code>VPC_EGRESS</code>).</p>"
+        },
+        "State":{
+          "shape":"NetworkConnectorState",
+          "documentation":"<p>The current state of the network connector.</p>"
+        },
+        "LastModified":{
+          "shape":"CoreTimestamp",
+          "documentation":"<p>The date and time when the connector was last modified.</p>"
+        }
+      },
+      "documentation":"<p>Summary information about a network connector returned by <code>ListNetworkConnectors</code>. Contains identifying fields and current state. To retrieve full configuration details, use <code>GetNetworkConnector</code>.</p>"
+    },
+    "NetworkConnectorTagKey":{
+      "type":"string",
+      "max":128,
+      "min":1,
+      "pattern":"([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)"
+    },
+    "NetworkConnectorTagValue":{
+      "type":"string",
+      "max":256,
+      "min":0,
+      "pattern":"([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)"
+    },
+    "NetworkConnectorTags":{
+      "type":"map",
+      "key":{"shape":"NetworkConnectorTagKey"},
+      "value":{"shape":"NetworkConnectorTagValue"}
+    },
+    "NetworkConnectorType":{
+      "type":"string",
+      "enum":["VPC_EGRESS"]
+    },
+    "NetworkConnectorVersion":{
+      "type":"long",
+      "box":true,
+      "min":0
+    },
+    "NetworkConnectorVpcEgressConfiguration":{
+      "type":"structure",
+      "members":{
+        "SubnetIds":{
+          "shape":"NetworkConnectorSubnetIds",
+          "documentation":"<p>The IDs of the VPC subnets where Lambda provisions elastic network interfaces (ENIs). Specify 1 to 16 subnets. All subnets must be in the same VPC.</p>"
+        },
+        "SecurityGroupIds":{
+          "shape":"NetworkConnectorSecurityGroupIds",
+          "documentation":"<p>The IDs of the VPC security groups to attach to the ENIs. Specify 0 to 5 security groups. All security groups must be in the same VPC as the subnets.</p>"
+        },
+        "NetworkProtocol":{
+          "shape":"NetworkProtocol",
+          "documentation":"<p>The network protocol for the connector. Specify <code>IPv4</code> for IPv4-only networking, or <code>DualStack</code> for both IPv4 and IPv6.</p>"
+        },
+        "AssociatedComputeResourceTypes":{
+          "shape":"AssociatedComputeResourceTypesList",
+          "documentation":"<p>The types of Lambda compute resources that can use this connector. Currently, only <code>MicroVm</code> is supported.</p>"
+        }
+      },
+      "documentation":"<p>Configuration for a VPC egress network connector. Specifies the VPC subnets, security groups, network protocol, and associated Lambda compute resource types.</p>"
+    },
+    "NetworkConnectorsList":{
+      "type":"list",
+      "member":{"shape":"NetworkConnectorSummary"},
+      "max":50,
+      "min":0
+    },
+    "NetworkProtocol":{
+      "type":"string",
+      "enum":[
+        "IPv4",
+        "DualStack"
+      ]
+    },
+    "ResourceConflictException":{
+      "type":"structure",
+      "members":{
+        "Type":{
+          "shape":"String",
+          "documentation":"<p>The exception type.</p>"
+        },
+        "message":{"shape":"String"}
+      },
+      "documentation":"<p>The request could not be completed due to a conflict with the current state of the resource. For example, attempting to update a connector that is not in <code>ACTIVE</code> state.</p>",
+      "error":{
+        "httpStatusCode":409,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "ResourceNotFoundException":{
+      "type":"structure",
+      "members":{
+        "Type":{
+          "shape":"String",
+          "documentation":"<p>The exception type.</p>"
+        },
+        "Message":{"shape":"String"}
+      },
+      "documentation":"<p>The specified network connector does not exist. Verify the identifier (ID, name, or ARN) and Region.</p>",
+      "error":{
+        "httpStatusCode":404,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "ServiceException":{
+      "type":"structure",
+      "members":{
+        "Type":{
+          "shape":"String",
+          "documentation":"<p>The exception type.</p>"
+        },
+        "Message":{"shape":"String"}
+      },
+      "documentation":"<p>An internal service error occurred. Retry the request with exponential backoff.</p>",
+      "error":{"httpStatusCode":500},
+      "exception":true,
+      "fault":true
+    },
+    "String":{"type":"string"},
+    "ThrottleReason":{
+      "type":"string",
+      "enum":[
+        "ConcurrentInvocationLimitExceeded",
+        "FunctionInvocationRateLimitExceeded",
+        "ReservedFunctionConcurrentInvocationLimitExceeded",
+        "ReservedFunctionInvocationRateLimitExceeded",
+        "CallerRateLimitExceeded",
+        "ConcurrentSnapshotCreateLimitExceeded"
+      ]
+    },
+    "TooManyRequestsException":{
+      "type":"structure",
+      "members":{
+        "retryAfterSeconds":{
+          "shape":"String",
+          "documentation":"<p>The number of seconds to wait before retrying the request.</p>",
+          "location":"header",
+          "locationName":"Retry-After"
+        },
+        "Type":{
+          "shape":"String",
+          "documentation":"<p>The exception type.</p>"
+        },
+        "message":{"shape":"String"},
+        "Reason":{
+          "shape":"ThrottleReason",
+          "documentation":"<p>The reason for the throttling.</p>"
+        }
+      },
+      "documentation":"<p>The request was throttled due to exceeding the allowed request rate. Retry the request after a brief wait using exponential backoff.</p>",
+      "error":{
+        "httpStatusCode":429,
+        "senderFault":true
+      },
+      "exception":true
+    },
+    "UpdateNetworkConnectorRequest":{
+      "type":"structure",
+      "required":["Identifier"],
+      "members":{
+        "Identifier":{
+          "shape":"NetworkConnectorIdentifier",
+          "location":"uri",
+          "locationName":"Identifier"
+        },
+        "Configuration":{
+          "shape":"NetworkConnectorConfiguration",
+          "documentation":"<p>The updated network configuration for the connector. Provide the full <code>VpcEgressConfiguration</code> including all subnet IDs and security group IDs — this replaces the existing configuration.</p>"
+        },
+        "OperatorRole":{
+          "shape":"NetworkConnectorRoleArn",
+          "documentation":"<p>The updated ARN of the IAM role that Lambda assumes to manage ENIs. Use this to change the operator role without recreating the connector.</p>"
+        },
+        "ClientToken":{
+          "shape":"ClientTokenString",
+          "documentation":"<p>A unique, case-sensitive identifier to ensure idempotency of the update request.</p>",
+          "idempotencyToken":true
+        }
+      }
+    },
+    "UpdateNetworkConnectorResponse":{
+      "type":"structure",
+      "required":[
+        "Arn",
+        "Name",
+        "Id"
+      ],
+      "members":{
+        "Arn":{
+          "shape":"NetworkConnectorArn",
+          "documentation":"<p>The Amazon Resource Name (ARN) of the network connector.</p>"
+        },
+        "Name":{
+          "shape":"NetworkConnectorName",
+          "documentation":"<p>The name of the network connector.</p>"
+        },
+        "Id":{"shape":"NetworkConnectorId"},
+        "OperatorRole":{
+          "shape":"NetworkConnectorRoleArn",
+          "documentation":"<p>The ARN of the IAM role that Lambda uses to manage the underlying ENI resources for this connector.</p>"
+        },
+        "Configuration":{
+          "shape":"NetworkConnectorConfiguration",
+          "documentation":"<p>The network configuration of the connector, including VPC subnets and security groups.</p>"
+        },
+        "State":{
+          "shape":"NetworkConnectorState",
+          "documentation":"<p>The current state of the network connector.</p>"
+        },
+        "LastUpdateStatus":{
+          "shape":"NetworkConnectorLastUpdateStatus",
+          "documentation":"<p>The status of this update operation (typically <code>InProgress</code> immediately after the call).</p>"
+        },
+        "LastUpdateStatusReason":{
+          "shape":"NetworkConnectorLastUpdateStatusReason",
+          "documentation":"<p>A human-readable explanation of the update status.</p>"
+        },
+        "LastModified":{
+          "shape":"CoreTimestamp",
+          "documentation":"<p>The timestamp of this update.</p>"
+        }
+      }
+    }
+  },
+  "documentation":"<p>AWS Lambda Core is a set of APIs for managing shared infrastructure resources used by AWS Lambda. The Lambda Core API provides operations for creating and managing network connectors that enable Lambda MicroVMs to access resources in your Amazon Virtual Private Cloud (Amazon VPC).</p> <p>Network connectors provision elastic network interfaces (ENIs) in your VPC subnets, providing a managed network path from Lambda compute environments to private resources such as Amazon RDS databases, Amazon ElastiCache clusters, and internal APIs. You create a network connector once and attach it to one or more Lambda MicroVMs at run time.</p>"
+}

--- a/operator-controller/pom.xml
+++ b/operator-controller/pom.xml
@@ -28,6 +28,11 @@
             <artifactId>operator-aws-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ai.codriverlabs</groupId>
+            <artifactId>operator-aws-client-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Quarkus Operator SDK -->
         <dependency>

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMNetworkClient.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/aws/MicroVMNetworkClient.java
@@ -1,0 +1,75 @@
+package ai.codriverlabs.microvm.operator.controller.aws;
+
+import ai.codriverlabs.microvm.aws.lambdacore.LambdaCoreAsyncClient;
+import ai.codriverlabs.microvm.aws.lambdacore.model.*;
+import ai.codriverlabs.microvm.operator.core.model.MicroVMNetworkSpec;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import software.amazon.awssdk.regions.Region;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Wraps the generated LambdaCoreAsyncClient for Network Connector management.
+ * All operations correspond to the lambda-core API (2026-04-30).
+ */
+@ApplicationScoped
+public class MicroVMNetworkClient {
+
+    private final LambdaCoreAsyncClient sdk;
+
+    public MicroVMNetworkClient(
+            @ConfigProperty(name = "microvm.aws.region", defaultValue = "us-east-1") String region) {
+        this.sdk = LambdaCoreAsyncClient.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    public CompletableFuture<CreateNetworkConnectorResponse> createConnector(
+            String name, MicroVMNetworkSpec spec) {
+        var vpcConfig = NetworkConnectorVpcEgressConfiguration.builder()
+                .subnetIds(spec.getSubnetIds())
+                .securityGroupIds(spec.getSecurityGroupIds())
+                .networkProtocol(NetworkProtocol.fromValue(
+                        spec.getNetworkProtocol() != null ? spec.getNetworkProtocol() : "IPv4"))
+                .build();
+        var req = CreateNetworkConnectorRequest.builder()
+                .name(name)
+                .configuration(NetworkConnectorConfiguration.builder()
+                        .vpcEgressConfiguration(vpcConfig).build())
+                .operatorRole(spec.getOperatorRoleArn());
+        if (spec.getTags() != null) req.tags(spec.getTags());
+        return sdk.createNetworkConnector(req.build());
+    }
+
+    public CompletableFuture<GetNetworkConnectorResponse> getConnector(String connectorArn) {
+        return sdk.getNetworkConnector(GetNetworkConnectorRequest.builder()
+                .identifier(connectorArn).build());
+    }
+
+    public CompletableFuture<UpdateNetworkConnectorResponse> updateConnector(
+            String connectorArn, MicroVMNetworkSpec spec) {
+        var vpcConfig = NetworkConnectorVpcEgressConfiguration.builder()
+                .subnetIds(spec.getSubnetIds())
+                .securityGroupIds(spec.getSecurityGroupIds())
+                .networkProtocol(NetworkProtocol.fromValue(
+                        spec.getNetworkProtocol() != null ? spec.getNetworkProtocol() : "IPv4"))
+                .build();
+        return sdk.updateNetworkConnector(UpdateNetworkConnectorRequest.builder()
+                .identifier(connectorArn)
+                .configuration(NetworkConnectorConfiguration.builder()
+                        .vpcEgressConfiguration(vpcConfig).build())
+                .build());
+    }
+
+    public CompletableFuture<DeleteNetworkConnectorResponse> deleteConnector(String connectorArn) {
+        return sdk.deleteNetworkConnector(DeleteNetworkConnectorRequest.builder()
+                .identifier(connectorArn).build());
+    }
+
+    public CompletableFuture<List<NetworkConnectorSummary>> listConnectors() {
+        return sdk.listNetworkConnectors(ListNetworkConnectorsRequest.builder().build())
+                .thenApply(r -> r.networkConnectors());
+    }
+}

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMNetworkReconciler.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMNetworkReconciler.java
@@ -1,0 +1,131 @@
+package ai.codriverlabs.microvm.operator.controller.reconciler;
+
+import ai.codriverlabs.microvm.aws.lambdacore.model.GetNetworkConnectorResponse;
+import ai.codriverlabs.microvm.aws.lambdacore.model.NetworkConnectorState;
+import ai.codriverlabs.microvm.operator.controller.aws.MicroVMNetworkClient;
+import ai.codriverlabs.microvm.operator.core.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.*;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+import ai.codriverlabs.microvm.aws.lambdacore.model.ResourceNotFoundException;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@ControllerConfiguration(
+        finalizerName = "lambda.aws.amazon.com/network-connector-finalizer",
+        name = "microvmnetwork-reconciler"
+)
+public class MicroVMNetworkReconciler implements Reconciler<MicroVMNetwork>, Cleaner<MicroVMNetwork> {
+
+    private static final Logger LOG = Logger.getLogger(MicroVMNetworkReconciler.class);
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(15);
+    private static final Duration RESYNC = Duration.ofMinutes(5);
+    private static final long AWS_TIMEOUT_S = 30;
+
+    @Inject
+    MicroVMNetworkClient networkClient;
+
+    @Inject
+    KubernetesClient k8s;
+
+    @Override
+    public UpdateControl<MicroVMNetwork> reconcile(MicroVMNetwork resource, Context<MicroVMNetwork> context) {
+        var spec = resource.getSpec();
+        if (resource.getStatus() == null) resource.setStatus(new MicroVMNetworkStatus());
+        var status = resource.getStatus();
+
+        try {
+            // CREATE: connector ARN not yet set
+            if (status.getConnectorArn() == null) {
+                String name = resource.getMetadata().getNamespace() + "-" + resource.getMetadata().getName();
+                var resp = networkClient.createConnector(name, spec).get(AWS_TIMEOUT_S, TimeUnit.SECONDS);
+                status.setConnectorArn(resp.arn());
+                status.setConnectorId(resp.id());
+                status.setConnectorState("PENDING");
+                LOG.infof("Created network connector %s for MicroVMNetwork %s", resp.arn(),
+                        resource.getMetadata().getName());
+                return UpdateControl.patchStatus(resource).rescheduleAfter(POLL_INTERVAL);
+            }
+
+            // POLL or UPDATE
+            var current = networkClient.getConnector(status.getConnectorArn())
+                    .get(AWS_TIMEOUT_S, TimeUnit.SECONDS);
+
+            // Spec changed — trigger update (best-effort, may fail if MicroVMs are running)
+            long generation = resource.getMetadata().getGeneration() != null
+                    ? resource.getMetadata().getGeneration() : 0L;
+            if (status.getObservedGeneration() != null && status.getObservedGeneration() < generation) {
+                networkClient.updateConnector(status.getConnectorArn(), spec).get(AWS_TIMEOUT_S, TimeUnit.SECONDS);
+                status.setConnectorState("PENDING");
+                LOG.infof("Updated network connector %s", status.getConnectorArn());
+            }
+
+            updateStatusFromAws(status, current, generation);
+
+            return switch (current.state()) {
+                case PENDING -> UpdateControl.patchStatus(resource).rescheduleAfter(POLL_INTERVAL);
+                case ACTIVE -> UpdateControl.patchStatus(resource).rescheduleAfter(RESYNC);
+                case FAILED, DELETE_FAILED -> {
+                    LOG.warnf("Network connector %s in state %s: %s",
+                            status.getConnectorArn(), current.stateAsString(), current.stateReason());
+                    yield UpdateControl.patchStatus(resource).rescheduleAfter(RESYNC);
+                }
+                default -> UpdateControl.patchStatus(resource).rescheduleAfter(POLL_INTERVAL);
+            };
+
+        } catch (Exception e) {
+            LOG.errorf(e, "Error reconciling MicroVMNetwork %s", resource.getMetadata().getName());
+            return UpdateControl.patchStatus(resource).rescheduleAfter(POLL_INTERVAL);
+        }
+    }
+
+    @Override
+    public DeleteControl cleanup(MicroVMNetwork resource, Context<MicroVMNetwork> context) {
+        var status = resource.getStatus();
+        if (status == null || status.getConnectorArn() == null) {
+            return DeleteControl.defaultDelete();
+        }
+
+        // Block deletion if any MicroVM still references this network
+        String networkName = resource.getMetadata().getName();
+        String namespace = resource.getMetadata().getNamespace();
+        List<MicroVM> using = k8s.resources(MicroVM.class).inNamespace(namespace).list().getItems()
+                .stream()
+                .filter(vm -> networkName.equals(vm.getSpec() != null ? vm.getSpec().getNetworkRef() : null))
+                .toList();
+
+        if (!using.isEmpty()) {
+            LOG.warnf("MicroVMNetwork %s still in use by %d MicroVM(s), blocking deletion", networkName, using.size());
+            return DeleteControl.noFinalizerRemoval();
+        }
+
+        try {
+            networkClient.deleteConnector(status.getConnectorArn()).get(AWS_TIMEOUT_S, TimeUnit.SECONDS);
+            LOG.infof("Deleted network connector %s", status.getConnectorArn());
+        } catch (Exception e) {
+            // ResourceNotFoundException means already gone — safe to proceed
+            if (!(e.getCause() instanceof ResourceNotFoundException)) {
+                LOG.errorf(e, "Failed to delete network connector %s", status.getConnectorArn());
+                return DeleteControl.noFinalizerRemoval();
+            }
+        }
+        return DeleteControl.defaultDelete();
+    }
+
+    private void updateStatusFromAws(MicroVMNetworkStatus status, GetNetworkConnectorResponse r, long generation) {
+        status.setConnectorState(r.stateAsString());
+        status.setStateReason(r.stateReason());
+        status.setStateReasonCode(r.stateReasonCodeAsString());
+        status.setObservedGeneration(generation);
+        status.setConditions(List.of(new Condition(
+                "Ready",
+                r.state() == NetworkConnectorState.ACTIVE ? "True" : "False",
+                r.state() == NetworkConnectorState.ACTIVE ? "ConnectorActive" : r.stateAsString(),
+                r.stateReason(),
+                java.time.Instant.now()
+        )));
+    }
+}

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMNetwork.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMNetwork.java
@@ -9,5 +9,5 @@ import io.fabric8.kubernetes.model.annotation.*;
 @Kind("MicroVMNetwork")
 @Singular("microvmnetwork")
 @Plural("microvmnetworks")
-public class MicroVMNetwork extends CustomResource<MicroVMNetworkSpec, Void> implements Namespaced {
+public class MicroVMNetwork extends CustomResource<MicroVMNetworkSpec, MicroVMNetworkStatus> implements Namespaced {
 }

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMNetworkSpec.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMNetworkSpec.java
@@ -2,35 +2,47 @@ package ai.codriverlabs.microvm.operator.core.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MicroVMNetworkSpec {
-    private String vpcId;
     private List<String> subnetIds;
     private List<String> securityGroupIds;
+    /** IAM role ARN that Lambda assumes to create ENIs in the customer VPC. */
+    private String operatorRoleArn;
+    /** IPv4 (default) or DualStack */
+    private String networkProtocol = "IPv4";
+    private String region;
+    private Map<String, String> tags;
 
     public MicroVMNetworkSpec() {}
 
-    public String getVpcId() { return vpcId; }
-    public void setVpcId(String vpcId) { this.vpcId = vpcId; }
     public List<String> getSubnetIds() { return subnetIds; }
     public void setSubnetIds(List<String> subnetIds) { this.subnetIds = subnetIds; }
     public List<String> getSecurityGroupIds() { return securityGroupIds; }
     public void setSecurityGroupIds(List<String> securityGroupIds) { this.securityGroupIds = securityGroupIds; }
+    public String getOperatorRoleArn() { return operatorRoleArn; }
+    public void setOperatorRoleArn(String operatorRoleArn) { this.operatorRoleArn = operatorRoleArn; }
+    public String getNetworkProtocol() { return networkProtocol; }
+    public void setNetworkProtocol(String networkProtocol) { this.networkProtocol = networkProtocol; }
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MicroVMNetworkSpec s = (MicroVMNetworkSpec) o;
-        return Objects.equals(vpcId, s.vpcId) && Objects.equals(subnetIds, s.subnetIds) &&
-               Objects.equals(securityGroupIds, s.securityGroupIds);
+        return Objects.equals(subnetIds, s.subnetIds)
+                && Objects.equals(securityGroupIds, s.securityGroupIds)
+                && Objects.equals(operatorRoleArn, s.operatorRoleArn)
+                && Objects.equals(networkProtocol, s.networkProtocol)
+                && Objects.equals(region, s.region);
     }
 
     @Override
-    public int hashCode() { return Objects.hash(vpcId, subnetIds, securityGroupIds); }
-
-    @Override
-    public String toString() { return "MicroVMNetworkSpec{vpcId='" + vpcId + "', subnets=" + subnetIds + ", securityGroups=" + securityGroupIds + "}"; }
+    public int hashCode() { return Objects.hash(subnetIds, securityGroupIds, operatorRoleArn, networkProtocol, region); }
 }

--- a/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMNetworkStatus.java
+++ b/operator-core/src/main/java/ai/codriverlabs/microvm/operator/core/model/MicroVMNetworkStatus.java
@@ -1,0 +1,33 @@
+package ai.codriverlabs.microvm.operator.core.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MicroVMNetworkStatus {
+    private String connectorArn;
+    private String connectorId;
+    /** PENDING | ACTIVE | INACTIVE | FAILED | DELETING | DELETE_FAILED */
+    private String connectorState;
+    private String stateReason;
+    private String stateReasonCode;
+    private Long observedGeneration;
+    private List<Condition> conditions;
+
+    public MicroVMNetworkStatus() {}
+
+    public String getConnectorArn() { return connectorArn; }
+    public void setConnectorArn(String connectorArn) { this.connectorArn = connectorArn; }
+    public String getConnectorId() { return connectorId; }
+    public void setConnectorId(String connectorId) { this.connectorId = connectorId; }
+    public String getConnectorState() { return connectorState; }
+    public void setConnectorState(String connectorState) { this.connectorState = connectorState; }
+    public String getStateReason() { return stateReason; }
+    public void setStateReason(String stateReason) { this.stateReason = stateReason; }
+    public String getStateReasonCode() { return stateReasonCode; }
+    public void setStateReasonCode(String stateReasonCode) { this.stateReasonCode = stateReasonCode; }
+    public Long getObservedGeneration() { return observedGeneration; }
+    public void setObservedGeneration(Long observedGeneration) { this.observedGeneration = observedGeneration; }
+    public List<Condition> getConditions() { return conditions; }
+    public void setConditions(List<Condition> conditions) { this.conditions = conditions; }
+}

--- a/operator-core/src/test/java/ai/codriverlabs/microvm/operator/core/CrdSerializationPropertyTest.java
+++ b/operator-core/src/test/java/ai/codriverlabs/microvm/operator/core/CrdSerializationPropertyTest.java
@@ -144,14 +144,12 @@ class CrdSerializationPropertyTest {
     @Provide
     Arbitrary<MicroVMNetworkSpec> validMicroVMNetworkSpec() {
         return Combinators.combine(
-            Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(15).map(s -> "vpc-" + s),
             Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10)
                 .map(s -> "subnet-" + s).list().ofMinSize(1).ofMaxSize(6),
             Arbitraries.strings().withCharRange('a', 'z').ofMinLength(5).ofMaxLength(10)
                 .map(s -> "sg-" + s).list().ofMinSize(1).ofMaxSize(5)
-        ).as((vpc, subnets, sgs) -> {
+        ).as((subnets, sgs) -> {
             MicroVMNetworkSpec spec = new MicroVMNetworkSpec();
-            spec.setVpcId(vpc);
             spec.setSubnetIds(subnets);
             spec.setSecurityGroupIds(sgs);
             return spec;

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>operator-core</module>
         <module>operator-aws-client</module>
+        <module>operator-aws-client-core</module>
         <module>operator-controller</module>
         <module>operator-webhook</module>
         <module>operator-cli</module>


### PR DESCRIPTION
## New module: operator-aws-client-core
Generated `LambdaCoreClient` from `lambda-core/2026-04-30` botocore service model (same pattern as `operator-aws-client`).

## MicroVMNetwork reconciler
- **CREATE**: `CreateNetworkConnector` → poll PENDING→ACTIVE
- **UPDATE**: `UpdateNetworkConnector` on spec generation change
- **DELETE**: blocks finalizer while MicroVMs still reference this network; calls `DeleteNetworkConnector`

## Model changes
- `MicroVMNetworkSpec`: removed `vpcId` (not an API param), added `operatorRoleArn`, `networkProtocol`, `region`, `tags`
- `MicroVMNetworkStatus`: new class (`connectorArn`, `connectorState`, `conditions`)

Tests: 23 passing