### PR TITLE
fix: MicroVMNetworkReconciler poll interval 15s → 5s

### DIFF
--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMNetworkReconciler.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMNetworkReconciler.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 public class MicroVMNetworkReconciler implements Reconciler<MicroVMNetwork>, Cleaner<MicroVMNetwork> {
 
     private static final Logger LOG = Logger.getLogger(MicroVMNetworkReconciler.class);
-    private static final Duration POLL_INTERVAL = Duration.ofSeconds(15);
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(5);
     private static final Duration RESYNC = Duration.ofMinutes(5);
     private static final long AWS_TIMEOUT_S = 30;
 


### PR DESCRIPTION
ENI provisioning typically completes in <60s. Polling every 5s means faster readiness detection (~12 polls max vs ~4 at 15s). Network connectors are low-volume resources so GetNetworkConnector throttling is not a concern.