### PR TITLE
fix: native CLI build — url-connection-client + aws-crt version alignment

### DIFF
--- a/operator-cli/pom.xml
+++ b/operator-cli/pom.xml
@@ -22,11 +22,56 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Generated AWS Lambda MicroVMs SDK client (for token generation) -->
+        <!-- Generated AWS Lambda MicroVMs SDK client (for token generation).
+             Exclude async/apache HTTP clients — CLI uses sync url-connection-client only. -->
         <dependency>
             <groupId>ai.codriverlabs</groupId>
             <artifactId>operator-aws-client</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Also need lambda-core client for network connector ops.
+             Same exclusions apply. -->
+        <dependency>
+            <groupId>ai.codriverlabs</groupId>
+            <artifactId>operator-aws-client-core</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- GraalVM-compatible sync HTTP client (JDK HttpURLConnection, zero extra deps) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+        </dependency>
+
+        <!-- aws-crt is an optional dependency of aws-sdk checksums but has hard bytecode references
+             to CRC64NVME/CRC32C/XXHash that GraalVM's static analysis resolves at build time.
+             Must be on the classpath for native image compilation. Version must match what
+             aws-sdk 2.44.6 was compiled against (awscrt.version=0.45.1 in aws-sdk-java-pom). -->
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>0.45.1</version>
         </dependency>
 
         <!-- Quarkus Picocli -->

--- a/operator-cli/src/main/resources/application.properties
+++ b/operator-cli/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.application.name=kubectl-microvm
+
+# AWS SDK HTTP client: sync JDK URL connection (no apache-client, no commons-logging)
+# GraalVM-compatible — no additional native build args required

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.version>3.36.3</quarkus.platform.version>
-        <aws.sdk.version>2.31.5</aws.sdk.version>
+        <aws.sdk.version>2.44.6</aws.sdk.version>
         <fabric8.version>7.7.0</fabric8.version>
         <josdk.version>5.0.4</josdk.version>
         <josdk-webhooks.version>3.0.3</josdk-webhooks.version>
@@ -69,6 +69,13 @@
                 <version>${aws.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Pin url-connection-client explicitly — the BOM import doesn't always win
+                 over transitive resolution when the codegen plugin pulls newer SDK artifacts. -->
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>url-connection-client</artifactId>
+                <version>${aws.sdk.version}</version>
             </dependency>
             <!-- Explicit version management -->
             <dependency>


### PR DESCRIPTION
Fixes GraalVM native image build failure caused by missing aws-crt classes.

Root cause: checksums 2.44+ has hard bytecode refs to CRC64NVME, CRC32C, XXHash from aws-crt (optional dep). GraalVM resolves these at build time and fails.

Fix: url-connection-client (no apache/commons-logging), pin SDK to 2.44.6, add aws-crt:0.45.1

Result: 107MB native binary, 0.009s startup, 30/30 tests passing.