### PR TITLE
fix: add jib + native profiles to operator-controller pom

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -77,15 +77,15 @@ fi
 
 # Build Quarkus container-image flags
 image_flags() {
-  # Only build/push image when --push is set; otherwise skip image build entirely
+  # Only build/push image when --push is set
   if $PUSH; then
-    local flags="-Dquarkus.container-image.build=true -Dquarkus.container-image.push=true"
+    local flags="-Pjib"   # Jib: no local Docker needed, cross-compiles linux/amd64+arm64
+    flags+=" -Dquarkus.container-image.build=true -Dquarkus.container-image.push=true"
     flags+=" -Dquarkus.container-image.tag=${IMAGE_TAG}"
     [[ -n "$REGISTRY" ]] && flags+=" -Dquarkus.container-image.registry=${REGISTRY%%/*}"
     [[ -n "$REGISTRY" && "$REGISTRY" == */* ]] && flags+=" -Dquarkus.container-image.group=${REGISTRY#*/}"
     echo "$flags"
   else
-    # No image build — just compile and package
     echo "-Dquarkus.container-image.build=false"
   fi
 }

--- a/operator-controller/pom.xml
+++ b/operator-controller/pom.xml
@@ -140,4 +140,42 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- jib: cross-platform build without local Docker daemon.
+             Used for local dev builds targeting the EKS arm64 nodes.
+             Usage: ./mvnw package -Pjib -Dquarkus.container-image.push=true
+             Also activated by build-local.sh with the push flag. -->
+        <profile>
+            <id>jib</id>
+            <activation>
+                <property><name>jib</name></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
+                </dependency>
+            </dependencies>
+            <properties>
+                <quarkus.container-image.builder>jib</quarkus.container-image.builder>
+                <!-- Build for both arches so the image runs on amd64 CI and arm64 Graviton nodes -->
+                <quarkus.jib.platforms>linux/amd64,linux/arm64</quarkus.jib.platforms>
+            </properties>
+        </profile>
+
+        <!-- native: GraalVM native image build.
+             Used by CI (per-arch runners) and build-local.sh with the native flag. -->
+        <profile>
+            <id>native</id>
+            <activation>
+                <property><name>native</name></property>
+            </activation>
+            <properties>
+                <quarkus.native.enabled>true</quarkus.native.enabled>
+                <!-- container-build=false: native binary built on host, not inside Docker -->
+                <quarkus.native.container-build>false</quarkus.native.container-build>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Adds the two Maven profiles from eks-d-xpress-control-plane pattern:
- `jib`: Jib push (no Docker daemon), multi-arch `linux/amd64,linux/arm64`
- `native`: GraalVM native, `container-build=false`

build-local.sh updated to use `-Pjib` for push builds.