### PR TITLE
chore(deps): bump quarkus.platform.version from 3.37.4 to 3.38.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.37.4</quarkus.platform.version>
+        <quarkus.platform.version>3.38.0</quarkus.platform.version>
         <aws.sdk.version>2.50.0</aws.sdk.version>
         <jackson.version>2.22.1</jackson.version>
         <fabric8.version>7.8.0</fabric8.version>


### PR DESCRIPTION
Supersedes #53 (which had merge conflicts after other dependency PRs merged).

## Changes
- Quarkus platform 3.37.4 → 3.38.0

## Verification
- ✅ All 81 integration tests pass
- ✅ Native builds succeed (operator, CLI, auth-agent)

Closes #53