### PR TITLE
fix(reconciler): remove finalizer when MicroVM is already terminated or gone

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -130,17 +130,21 @@ fi
 if should_build "agent"; then
   echo "--- [3] operator-auth-agent"
   if $NATIVE; then
-    AGENT_IMAGE_FLAGS="-Dquarkus.container-image.build=true -Dquarkus.container-image.push=${PUSH}"
-    AGENT_IMAGE_FLAGS+=" -Dquarkus.container-image.tag=${IMAGE_TAG}"
-    [[ -n "${REGISTRY:-}" ]] && AGENT_IMAGE_FLAGS+=" -Dquarkus.container-image.registry=${REGISTRY%%/*}"
     ./mvnw -B -pl operator-auth-agent package $SKIP_FLAG -Dnative \
-      -Dquarkus.native.container-build=false \
-      $AGENT_IMAGE_FLAGS
+      -Dquarkus.native.container-build=false
+    if $PUSH; then
+      AGENT_REPO="${REGISTRY:+${REGISTRY}/}codriverlabs/kube-microvm-auth-agent"
+      AGENT_IMAGE="${AGENT_REPO}:${IMAGE_TAG}"
+      echo "==> Building auth-agent native image: ${AGENT_IMAGE}"
+      docker build -t "${AGENT_IMAGE}" -f operator-auth-agent/Dockerfile.native operator-auth-agent/
+      docker push "${AGENT_IMAGE}"
+      echo "==> Auth-agent image pushed: ${AGENT_IMAGE}"
+    fi
   else
     ./mvnw -B -pl operator-auth-agent package $SKIP_FLAG
     if $PUSH; then
       # JVM mode: build and push via Dockerfile
-      AGENT_REPO="${REGISTRY:+${REGISTRY}/}codriverlabs/microvm-auth-agent"
+      AGENT_REPO="${REGISTRY:+${REGISTRY}/}codriverlabs/kube-microvm-auth-agent"
       AGENT_IMAGE="${AGENT_REPO}:${IMAGE_TAG}"
       echo "==> Building auth-agent image: ${AGENT_IMAGE}"
       docker build -t "${AGENT_IMAGE}" -f operator-auth-agent/Dockerfile operator-auth-agent/

--- a/cleanup-operator.sh
+++ b/cleanup-operator.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# cleanup-operator.sh — full operator teardown for development redeployment
+#
+# Removes webhooks, patches out finalizers on all CRs, deletes CRs,
+# uninstalls the Helm release, and cleans up cert-manager resources.
+#
+# Usage:
+#   ./cleanup-operator.sh                    # default namespace: kube-microvm
+#   ./cleanup-operator.sh --namespace foo    # custom namespace
+#
+# Safe to run when operator is already gone (all operations are idempotent).
+#
+set -euo pipefail
+
+NAMESPACE="kube-microvm"
+RELEASE="kube-microvm-operator"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --namespace) NAMESPACE="$2"; shift ;;
+    --release)   RELEASE="$2"; shift ;;
+    --help)
+      echo "Usage: ./cleanup-operator.sh [--namespace <ns>] [--release <name>]"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+echo "==> [1/4] Deleting webhook configurations"
+kubectl delete validatingwebhookconfiguration kube-microvm-operator-validating --ignore-not-found
+kubectl delete mutatingwebhookconfiguration kube-microvm-operator-mutating --ignore-not-found
+
+echo "==> [2/4] Force-removing all custom resources (patching finalizers)"
+for cr in microvmimages microvms microvmreplicasets microvmnetworks; do
+  kubectl get $cr -A -o json 2>/dev/null | \
+    python3 -c "import json,sys; items=json.load(sys.stdin).get('items',[]); [print(i['metadata']['namespace']+'/'+i['metadata']['name']) for i in items]" 2>/dev/null | \
+    while read ns_name; do
+      ns="${ns_name%%/*}"; name="${ns_name##*/}"
+      kubectl patch $cr "$name" -n "$ns" --type=json \
+        -p='[{"op":"remove","path":"/metadata/finalizers"}]' --request-timeout=10s 2>/dev/null || true
+      kubectl delete $cr "$name" -n "$ns" --force --grace-period=0 --timeout=30s 2>/dev/null || true
+    done
+done
+
+echo "==> [3/4] Uninstalling Helm release: ${RELEASE}"
+helm uninstall "$RELEASE" -n "$NAMESPACE" --wait --timeout=60s 2>/dev/null || true
+
+echo "==> [4/4] Cleaning up cert-manager resources"
+kubectl delete secret kube-microvm-operator-webhook-tls kube-microvm-operator-ca \
+  -n "$NAMESPACE" --ignore-not-found
+kubectl delete certificate,issuer --all -n "$NAMESPACE" --ignore-not-found
+
+echo "==> Cleanup complete"

--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 SKIP_BUILD=false
 FROM_REGISTRY=false
 DRY_RUN=false
+CLEAN=false
 REGION="${AWS_REGION:-us-east-1}"
 CLUSTER=""
 AWS_PROFILE=""
@@ -29,6 +30,7 @@ while [[ $# -gt 0 ]]; do
       echo "Usage: ./deploy-local.sh [OPTIONS]"
       echo ""
       echo "Options:"
+      echo "  --clean               Full dev cleanup: delete webhooks, patch finalizers, uninstall chart"
       echo "  --skip-build          Skip Maven build; use existing chart tarball"
       echo "  --from-registry       Deploy from GHCR OCI (ignores local build)"
       echo "  --region <region>     AWS region (default: \$AWS_REGION or us-east-1)"
@@ -40,12 +42,13 @@ while [[ $# -gt 0 ]]; do
       echo "  --help                Show this help"
       echo ""
       echo "Examples:"
-      echo "  ./deploy-local.sh --region us-east-1 --cluster my-cluster"
-      echo "  ./deploy-local.sh --skip-build --dry-run"
+      echo "  ./deploy-local.sh --clean --region us-east-1 --cluster my-cluster"
+      echo "  ./deploy-local.sh --clean --skip-build"
       echo "  ./deploy-local.sh --from-registry --region us-east-2"
       echo "  ./deploy-local.sh --set 'app.envs.microvm\\.aws\\.region=us-west-2'"
       exit 0
       ;;
+    --clean)         CLEAN=true ;;
     --skip-build)    SKIP_BUILD=true ;;
     --from-registry) FROM_REGISTRY=true; SKIP_BUILD=true ;;
     --dry-run)       DRY_RUN=true ;;
@@ -172,16 +175,33 @@ print(json.dumps(doc))
   fi
 fi
 
-# Helm upgrade --install
-echo "==> helm upgrade --install ${RELEASE} (namespace: ${NAMESPACE}, dry-run: ${DRY_RUN})"
-helm upgrade --install "$RELEASE" "$CHART" \
-  --namespace "$NAMESPACE" \
-  --create-namespace \
-  --set "app.envs.AWS_REGION=${REGION}" \
-  $EXTRA_SET_ARGS \
-  $DRY_RUN_FLAG \
-  --wait \
-  --timeout 5m
+# Clean deploy: full teardown before install (per eks-deployment.md steering)
+if $CLEAN && ! $DRY_RUN; then
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  "${SCRIPT_DIR}/cleanup-operator.sh" --namespace "$NAMESPACE" --release "$RELEASE"
+fi
+
+# Helm install (clean) or upgrade --install (incremental)
+if $CLEAN && ! $DRY_RUN; then
+  echo "==> helm install ${RELEASE} (namespace: ${NAMESPACE})"
+  helm install "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --create-namespace \
+    --set "app.envs.AWS_REGION=${REGION}" \
+    $EXTRA_SET_ARGS \
+    --wait \
+    --timeout 5m
+else
+  echo "==> helm upgrade --install ${RELEASE} (namespace: ${NAMESPACE}, dry-run: ${DRY_RUN})"
+  helm upgrade --install "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --create-namespace \
+    --set "app.envs.AWS_REGION=${REGION}" \
+    $EXTRA_SET_ARGS \
+    $DRY_RUN_FLAG \
+    --wait \
+    --timeout 5m
+fi
 
 if ! $DRY_RUN; then
   echo ""

--- a/operator-auth-agent/Dockerfile.native
+++ b/operator-auth-agent/Dockerfile.native
@@ -1,0 +1,16 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+
+WORKDIR /deployments
+
+COPY --chown=1001:root target/*-runner /deployments/application
+
+RUN chmod 775 /deployments/application
+
+USER 1001
+
+EXPOSE 8090
+
+LABEL org.opencontainers.image.source="https://github.com/codriverlabs/KubeMicroVM" \
+      org.opencontainers.image.description="KubeMicroVM Auth Agent - sidecar for auto-refreshing MicroVM auth tokens"
+
+ENTRYPOINT ["./application"]

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMReconciler.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMReconciler.java
@@ -162,41 +162,56 @@ public class MicroVMReconciler implements Reconciler<MicroVM>, Cleaner<MicroVM> 
             status.setState(MicroVMState.TERMINATING);
             status.setLastTransitionTime(Instant.now());
             emitEvent(resource, "Terminating", "MicroVM deletion initiated");
+        }
 
-            // Call AWS destroy
+        // Attempt termination (covers both fresh transition and already-Terminating)
+        if (status.getState() == MicroVMState.TERMINATING || currentState == MicroVMState.TERMINATING) {
             try {
                 String vmId = status.getMicroVmId();
                 if (vmId != null) {
                     quotaGuard.terminateMicrovm(() -> microVMClient.terminateMicroVM(vmId))
                         .get(AWS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                 }
-                status.setState(MicroVMState.TERMINATED);
-                status.setLastTransitionTime(Instant.now());
-                metrics.recordStateTransition(MicroVMState.TERMINATING, MicroVMState.TERMINATED);
-                emitEvent(resource, "Terminated", "MicroVM successfully destroyed");
-                return DeleteControl.defaultDelete();
+                return terminationComplete(resource, status, namespace, name);
             } catch (Exception e) {
+                if (isAlreadyTerminatedOrGone(e)) {
+                    LOG.infof("MicroVM %s/%s already terminated or not found in AWS, removing finalizer",
+                            namespace, name);
+                    return terminationComplete(resource, status, namespace, name);
+                }
                 LOG.warnf(e, "Error destroying MicroVM %s/%s, retrying", namespace, name);
                 return DeleteControl.noFinalizerRemoval().rescheduleAfter(Duration.ofSeconds(10));
             }
         }
 
-        // If transition to Terminating is not valid (e.g., already Terminating)
-        if (currentState == MicroVMState.TERMINATING) {
-            try {
-                String vmId = status.getMicroVmId();
-                if (vmId != null) {
-                    quotaGuard.terminateMicrovm(() -> microVMClient.terminateMicroVM(vmId))
-                        .get(AWS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                }
-                status.setState(MicroVMState.TERMINATED);
-                return DeleteControl.defaultDelete();
-            } catch (Exception e) {
-                return DeleteControl.noFinalizerRemoval().rescheduleAfter(Duration.ofSeconds(10));
-            }
-        }
-
         return DeleteControl.defaultDelete();
+    }
+
+    private DeleteControl terminationComplete(MicroVM resource, MicroVMStatus status,
+                                              String namespace, String name) {
+        status.setState(MicroVMState.TERMINATED);
+        status.setLastTransitionTime(Instant.now());
+        metrics.recordStateTransition(MicroVMState.TERMINATING, MicroVMState.TERMINATED);
+        emitEvent(resource, "Terminated", "MicroVM successfully destroyed");
+        return DeleteControl.defaultDelete();
+    }
+
+    /**
+     * Checks whether a terminate exception indicates the MicroVM is already terminated
+     * or no longer exists — both are the desired end state for cleanup.
+     */
+    public static boolean isAlreadyTerminatedOrGone(Throwable t) {
+        Throwable cause = t;
+        // Unwrap ExecutionException / CompletionException from CompletableFuture.get()
+        while (cause.getCause() != null && (cause instanceof java.util.concurrent.ExecutionException
+                || cause instanceof java.util.concurrent.CompletionException)) {
+            cause = cause.getCause();
+        }
+        String className = cause.getClass().getSimpleName();
+        return className.contains("ResourceNotFoundException")
+                || className.contains("ConflictException")
+                || className.contains("ResourceConflictException")
+                || (cause instanceof AwsApiException ae && ae.isNotFound());
     }
 
     private void ensureStatusInitialized(MicroVM resource) {

--- a/operator-controller/src/test/java/ai/codriverlabs/microvm/operator/controller/MicroVMReconcilerTest.java
+++ b/operator-controller/src/test/java/ai/codriverlabs/microvm/operator/controller/MicroVMReconcilerTest.java
@@ -172,6 +172,56 @@ class MicroVMReconcilerTest {
         assertTrue(ex.isAuthFailure());
     }
 
+    @Test
+    @DisplayName("isAlreadyTerminatedOrGone: ResourceNotFoundException → true")
+    void isAlreadyTerminatedOrGone_resourceNotFound() {
+        var ex = new java.util.concurrent.ExecutionException(
+                software.amazon.awssdk.services.lambdamicrovms.model.ResourceNotFoundException
+                        .builder().message("not found").build());
+        assertTrue(MicroVMReconciler.isAlreadyTerminatedOrGone(ex));
+    }
+
+    @Test
+    @DisplayName("isAlreadyTerminatedOrGone: ConflictException → true")
+    void isAlreadyTerminatedOrGone_conflict() {
+        var ex = new java.util.concurrent.ExecutionException(
+                software.amazon.awssdk.services.lambdamicrovms.model.ConflictException
+                        .builder().message("already terminated").build());
+        assertTrue(MicroVMReconciler.isAlreadyTerminatedOrGone(ex));
+    }
+
+    @Test
+    @DisplayName("isAlreadyTerminatedOrGone: ResourceConflictException → true")
+    void isAlreadyTerminatedOrGone_resourceConflict() {
+        var ex = new java.util.concurrent.ExecutionException(
+                software.amazon.awssdk.services.lambdamicrovms.model.ResourceConflictException
+                        .builder().message("conflict").build());
+        assertTrue(MicroVMReconciler.isAlreadyTerminatedOrGone(ex));
+    }
+
+    @Test
+    @DisplayName("isAlreadyTerminatedOrGone: AwsApiException NOT_FOUND → true")
+    void isAlreadyTerminatedOrGone_awsApiNotFound() {
+        var ex = new AwsApiException("not found", AwsApiException.ErrorType.NOT_FOUND, "req-1", 404);
+        assertTrue(MicroVMReconciler.isAlreadyTerminatedOrGone(ex));
+    }
+
+    @Test
+    @DisplayName("isAlreadyTerminatedOrGone: TooManyRequestsException → false (transient)")
+    void isAlreadyTerminatedOrGone_throttling_false() {
+        var ex = new java.util.concurrent.ExecutionException(
+                software.amazon.awssdk.services.lambdamicrovms.model.TooManyRequestsException
+                        .builder().message("rate exceeded").build());
+        assertFalse(MicroVMReconciler.isAlreadyTerminatedOrGone(ex));
+    }
+
+    @Test
+    @DisplayName("isAlreadyTerminatedOrGone: generic RuntimeException → false")
+    void isAlreadyTerminatedOrGone_generic_false() {
+        var ex = new RuntimeException("network timeout");
+        assertFalse(MicroVMReconciler.isAlreadyTerminatedOrGone(ex));
+    }
+
     private MicroVM createMicroVM(String name, MicroVMState state) {
         MicroVM vm = new MicroVM();
         ObjectMeta meta = new ObjectMeta();

--- a/operator-tests/src/test/java/ai/codriverlabs/microvm/operator/tests/integration/MicroVMReconcilerIT.java
+++ b/operator-tests/src/test/java/ai/codriverlabs/microvm/operator/tests/integration/MicroVMReconcilerIT.java
@@ -139,6 +139,103 @@ class MicroVMReconcilerIT {
     }
 
     @Test
+    @DisplayName("DELETE: cleanup removes finalizer when terminate throws ResourceNotFoundException (VM already gone)")
+    void delete_resourceNotFound_removesFinalizer() throws Exception {
+        var vm = testMicroVM("test-vm-gone", MicroVMState.RUNNING);
+        vm.getStatus().setMicroVmId("mvm-gone123");
+
+        when(mockClient.terminateMicroVM("mvm-gone123")).thenReturn(
+                CompletableFuture.failedFuture(
+                        software.amazon.awssdk.services.lambdamicrovms.model.ResourceNotFoundException
+                                .builder().message("MicroVM mvm-gone123 not found").build()));
+
+        var deleteControl = reconciler.cleanup(vm, mockContext());
+
+        assertTrue(deleteControl.isRemoveFinalizer(),
+                "Finalizer should be removed when VM is not found in AWS");
+        assertEquals(MicroVMState.TERMINATED, vm.getStatus().getState());
+    }
+
+    @Test
+    @DisplayName("DELETE: cleanup removes finalizer when terminate throws ConflictException (VM already terminated)")
+    void delete_conflictAlreadyTerminated_removesFinalizer() throws Exception {
+        var vm = testMicroVM("test-vm-conflict", MicroVMState.RUNNING);
+        vm.getStatus().setMicroVmId("mvm-conflict123");
+
+        when(mockClient.terminateMicroVM("mvm-conflict123")).thenReturn(
+                CompletableFuture.failedFuture(
+                        software.amazon.awssdk.services.lambdamicrovms.model.ConflictException
+                                .builder().message("MicroVM is in TERMINATED state").build()));
+
+        var deleteControl = reconciler.cleanup(vm, mockContext());
+
+        assertTrue(deleteControl.isRemoveFinalizer(),
+                "Finalizer should be removed when VM is already terminated (conflict)");
+        assertEquals(MicroVMState.TERMINATED, vm.getStatus().getState());
+    }
+
+    @Test
+    @DisplayName("DELETE: cleanup removes finalizer when terminate throws ResourceConflictException")
+    void delete_resourceConflict_removesFinalizer() throws Exception {
+        var vm = testMicroVM("test-vm-resconflict", MicroVMState.RUNNING);
+        vm.getStatus().setMicroVmId("mvm-resconflict123");
+
+        when(mockClient.terminateMicroVM("mvm-resconflict123")).thenReturn(
+                CompletableFuture.failedFuture(
+                        software.amazon.awssdk.services.lambdamicrovms.model.ResourceConflictException
+                                .builder().message("Resource in conflicting state").build()));
+
+        var deleteControl = reconciler.cleanup(vm, mockContext());
+
+        assertTrue(deleteControl.isRemoveFinalizer(),
+                "Finalizer should be removed when VM has resource conflict (already terminated)");
+        assertEquals(MicroVMState.TERMINATED, vm.getStatus().getState());
+    }
+
+    @Test
+    @DisplayName("DELETE: cleanup retries on transient error (throttling)")
+    void delete_transientError_retries() throws Exception {
+        var vm = testMicroVM("test-vm-throttle", MicroVMState.RUNNING);
+        vm.getStatus().setMicroVmId("mvm-throttle123");
+
+        when(mockClient.terminateMicroVM("mvm-throttle123")).thenReturn(
+                CompletableFuture.failedFuture(
+                        software.amazon.awssdk.services.lambdamicrovms.model.TooManyRequestsException
+                                .builder().message("Rate exceeded").build()));
+
+        var deleteControl = reconciler.cleanup(vm, mockContext());
+
+        assertFalse(deleteControl.isRemoveFinalizer(),
+                "Finalizer should NOT be removed on transient errors — must retry");
+    }
+
+    @Test
+    @DisplayName("DELETE: cleanup removes finalizer when CR already in TERMINATED state")
+    void delete_alreadyTerminatedState_removesFinalizer() {
+        var vm = testMicroVM("test-vm-terminated", MicroVMState.TERMINATED);
+        vm.getStatus().setMicroVmId("mvm-terminated123");
+
+        var deleteControl = reconciler.cleanup(vm, mockContext());
+
+        assertTrue(deleteControl.isRemoveFinalizer(),
+                "Finalizer should be removed immediately when CR state is already TERMINATED");
+        verify(mockClient, never()).terminateMicroVM(any());
+    }
+
+    @Test
+    @DisplayName("DELETE: cleanup removes finalizer when status has no vmId (never provisioned)")
+    void delete_noVmId_removesFinalizer() {
+        var vm = testMicroVM("test-vm-noid", MicroVMState.PENDING);
+        // vmId is null — MicroVM was never successfully created in AWS
+
+        var deleteControl = reconciler.cleanup(vm, mockContext());
+
+        assertTrue(deleteControl.isRemoveFinalizer(),
+                "Finalizer should be removed when VM was never provisioned (no vmId)");
+        verify(mockClient, never()).terminateMicroVM(any());
+    }
+
+    @Test
     @DisplayName("PENDING with networkRef: resolves MicroVMNetwork CR to connector ARN")
     void pending_withNetworkRef_resolvesConnectorArn() throws Exception {
         // Create MicroVMNetwork with ACTIVE state


### PR DESCRIPTION
## Summary

Fixes #51 — MicroVM finalizer never removed after a successful terminate.

The cleanup loop retried `terminateMicroVM()` indefinitely when AWS returned ResourceNotFoundException, ConflictException, or ResourceConflictException — all of which indicate the VM is already in the desired end state.

## Changes

### Reconciler fix
- Short-circuit cleanup when CR state is already `TERMINATED`
- Treat null vmId (never provisioned) as cleanup-complete
- Add `isAlreadyTerminatedOrGone()` to detect terminal error responses
- Only retry on transient errors (throttling, timeouts)
- Extract `terminationComplete()` helper to deduplicate state transition logic

### Tooling improvements
- Add `cleanup-operator.sh`: standalone operator teardown script (webhooks, CRs, finalizers, helm uninstall, cert-manager)
- `deploy-local.sh`: add `--clean` flag that calls `cleanup-operator.sh` before fresh `helm install`
- `build-local.sh`: fix native auth-agent push (was using unconfigured Quarkus container-image properties that silently no-oped); now uses `Dockerfile.native` + `docker push`
- Add `operator-auth-agent/Dockerfile.native` for native image builds
- Fix auth-agent ECR repo name: `codriverlabs/kube-microvm-auth-agent`

## Testing

- 6 unit tests for `isAlreadyTerminatedOrGone()` (positive + negative cases)
- 6 integration tests covering: ResourceNotFound, ConflictException, ResourceConflictException, throttling retry, already-TERMINATED state, null vmId
- Full suite passes: 87 tests, 0 failures
- Native build: all 3 binaries compile successfully
- **UAT on live EKS**: RS-06 (Delete ReplicaSet Terminates All VMs) — PASS