### PR TITLE
fix: honour AWS_ENDPOINT_URL_STS in startup health check

### DIFF
--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/health/AwsConnectivityStartup.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/health/AwsConnectivityStartup.java
@@ -4,6 +4,8 @@ import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import java.net.URI;
+import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import software.amazon.awssdk.regions.Region;
@@ -17,11 +19,16 @@ public class AwsConnectivityStartup {
     @ConfigProperty(name = "aws.region", defaultValue = "us-east-1")
     String region;
 
+    @ConfigProperty(name = "aws.sts.endpoint")
+    Optional<String> stsEndpoint;
+
     @Inject
     AwsIdentity awsIdentity;
 
     void onStart(@Observes StartupEvent ev) {
-        try (StsClient sts = StsClient.builder().region(Region.of(region)).build()) {
+        var builder = StsClient.builder().region(Region.of(region));
+        stsEndpoint.filter(s -> !s.isBlank()).ifPresent(e -> builder.endpointOverride(URI.create(e)));
+        try (StsClient sts = builder.build()) {
             var identity = sts.getCallerIdentity();
             LOG.infof("AWS connectivity confirmed: account=%s arn=%s",
                     identity.account(), identity.arn());
@@ -29,7 +36,7 @@ public class AwsConnectivityStartup {
             AwsConnectivityHealthCheck.setAwsConnectivityConfirmed(true);
             AwsConnectivityHealthCheck.setInformerCachesSynced(true);
         } catch (Exception e) {
-            LOG.warnf("AWS connectivity check failed: %s", e.getMessage());
+            LOG.warnf("AWS connectivity check failed (STS GetCallerIdentity): %s", e.getMessage());
         }
     }
 }

--- a/operator-controller/src/main/resources/application.properties
+++ b/operator-controller/src/main/resources/application.properties
@@ -19,6 +19,7 @@ aws.quota.concurrent-image-builds=${AWS_QUOTA_CONCURRENT_IMAGE_BUILDS:10}
 aws.quota.token-queue-size=${AWS_QUOTA_TOKEN_QUEUE_SIZE:200}
 aws.quota.discovery.enabled=${AWS_QUOTA_DISCOVERY:false}
 aws.microvm.endpoint=${AWS_MICROVM_ENDPOINT:}
+aws.sts.endpoint=${AWS_ENDPOINT_URL_STS:}
 
 # Quarkus Operator SDK
 quarkus.operator-sdk.start-operator=true


### PR DESCRIPTION
## Summary

The STS client in `AwsConnectivityStartup` did not support endpoint overrides, causing the operator to never become ready when STS is unreachable (e.g. k3d with emulated endpoints).

## Changes

- Apply the same `endpointOverride` pattern used by the MicroVM clients: read `aws.sts.endpoint` from `AWS_ENDPOINT_URL_STS` env var and pass it to the StsClient builder
- Improve the error message to explicitly mention "STS GetCallerIdentity" for easier diagnosis

## Testing

- All 90 integration tests pass
- Native build (operator, CLI, auth-agent) compiles successfully

Closes #50