### PR TITLE
fix(deps): exclude unused apache5-client to resolve httpclient5 CVE

### DIFF
--- a/operator-cli/pom.xml
+++ b/operator-cli/pom.xml
@@ -35,6 +35,10 @@
                 </exclusion>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache5-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
                     <artifactId>netty-nio-client</artifactId>
                 </exclusion>
             </exclusions>
@@ -50,6 +54,10 @@
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>
                     <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache5-client</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>

--- a/operator-controller/pom.xml
+++ b/operator-controller/pom.xml
@@ -43,11 +43,23 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>lambdamicrovms</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache5-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>lambdacore</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache5-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Quarkus Operator SDK -->
@@ -117,6 +129,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>servicequotas</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache5-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- AWS URL Connection Client -->

--- a/operator-tests/pom.xml
+++ b/operator-tests/pom.xml
@@ -24,11 +24,23 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>lambdamicrovms</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache5-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>lambdacore</artifactId>
             <version>${aws.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache5-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ai.codriverlabs</groupId>


### PR DESCRIPTION
## Summary

Excludes the unused `apache5-client` transitive dependency from the AWS SDK modules (`lambdamicrovms`, `lambdacore`, `servicequotas`) across all three affected modules.

This removes `httpclient5:5.6.1` from the dependency tree entirely — we never use it (operator uses `netty-nio-client` for async and `url-connection-client` for sync; CLI uses `url-connection-client` only).

## CVE

**Apache HttpComponents Client: Connection Leak on Content-Encoding Decode Error Leads to Pool Exhaustion DoS** (medium severity)

## Changes

- `operator-controller/pom.xml` — exclude `apache5-client` from `lambdamicrovms`, `lambdacore`, `servicequotas`
- `operator-cli/pom.xml` — add `apache5-client` exclusion (already excluded v4 `apache-client`)
- `operator-tests/pom.xml` — exclude `apache5-client` from `lambdamicrovms`, `lambdacore`

## Testing

- All 90 integration tests pass
- Native build (operator, CLI, auth-agent) compiles successfully
- `mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5` returns empty

Resolves Dependabot alerts #20, #21, #22.