### PR TITLE
feat: extraEnvs support, cert-manager check, namespace guidance, darwin CLI

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -76,8 +76,16 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-latest
+            os: linux
           - arch: arm64
             runner: ubuntu-24.04-arm
+            os: linux
+          - arch: amd64
+            runner: macos-13
+            os: darwin
+          - arch: arm64
+            runner: macos-14
+            os: darwin
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
@@ -99,15 +107,15 @@ jobs:
       - name: Rename binary
         run: |
           BINARY=$(find operator-cli/target -name "*-runner" -type f | head -1)
-          cp "$BINARY" microvm-linux-${{ matrix.arch }}
-          chmod +x microvm-linux-${{ matrix.arch }}
-          file microvm-linux-${{ matrix.arch }}
+          cp "$BINARY" microvm-${{ matrix.os }}-${{ matrix.arch }}
+          chmod +x microvm-${{ matrix.os }}-${{ matrix.arch }}
+          file microvm-${{ matrix.os }}-${{ matrix.arch }}
       - name: Smoke test
-        run: timeout 5 ./microvm-linux-${{ matrix.arch }} --help || true
+        run: timeout 5 ./microvm-${{ matrix.os }}-${{ matrix.arch }} --help || true
       - uses: actions/upload-artifact@v7
         with:
-          name: microvm-linux-${{ matrix.arch }}
-          path: microvm-linux-${{ matrix.arch }}
+          name: microvm-${{ matrix.os }}-${{ matrix.arch }}
+          path: microvm-${{ matrix.os }}-${{ matrix.arch }}
           retention-days: 7
 
   # ─── Container images (per arch) ─────────────────────────────────────────
@@ -248,18 +256,17 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          # Quarkus Helm generates the chart with image tag and version baked in
+          # Quarkus Helm generates the chart with image tag and version baked in.
+          # Auth-agent image version is set via quarkus.helm.values.authAgentImage.value.
           ./mvnw -B -pl operator-core,operator-spi,operator-webhook,operator-controller \
             package -DskipTests --no-transfer-progress \
             -Dquarkus.helm.version=${VERSION} \
             -Dquarkus.helm.create-tar-file=true \
             -Dquarkus.container-image.tag=${VERSION} \
-            -Dquarkus.container-image.build=false
-          # Patch auth-agent image tag in generated Helm values (Quarkus can't resolve
-          # cross-property references in env var defaults at chart generation time)
+            -Dquarkus.container-image.build=false \
+            -Dquarkus.helm.values.authAgentImage.value=ghcr.io/codriverlabs/microvm-auth-agent:${VERSION}
           CHART_DIR="operator-controller/target/helm/kubernetes/kube-microvm-operator"
-          sed -i "s|microvm-auth-agent:latest|microvm-auth-agent:${VERSION}|g" "${CHART_DIR}/values.yaml"
-          # Re-package the chart with corrected values
+          # Re-package with correct version metadata
           rm -f "${CHART_DIR}/../kube-microvm-operator-${VERSION}.tar.gz"
           helm package "${CHART_DIR}" --version "${VERSION}" --app-version "${VERSION}" \
             -d operator-controller/target/helm/kubernetes/
@@ -293,17 +300,25 @@ jobs:
           path: dist/
       - uses: actions/download-artifact@v8
         with:
+          name: microvm-darwin-amd64
+          path: dist/
+      - uses: actions/download-artifact@v8
+        with:
+          name: microvm-darwin-arm64
+          path: dist/
+      - uses: actions/download-artifact@v8
+        with:
           name: helm-chart
           path: dist/
       - name: Generate checksums
         working-directory: dist
         run: |
           # Individual .sha256 per artifact
-          for f in microvm-linux-amd64 microvm-linux-arm64 kube-microvm-operator-*.tgz; do
+          for f in microvm-linux-amd64 microvm-linux-arm64 microvm-darwin-amd64 microvm-darwin-arm64 kube-microvm-operator-*.tgz; do
             sha256sum "$f" > "$f.sha256"
           done
           # Combined checksums.sha256
-          sha256sum microvm-linux-amd64 microvm-linux-arm64 kube-microvm-operator-*.tgz > checksums.sha256
+          sha256sum microvm-linux-amd64 microvm-linux-arm64 microvm-darwin-amd64 microvm-darwin-arm64 kube-microvm-operator-*.tgz > checksums.sha256
       - uses: actions/checkout@v7
         with:
           path: repo
@@ -325,6 +340,10 @@ jobs:
             dist/microvm-linux-amd64.sha256
             dist/microvm-linux-arm64
             dist/microvm-linux-arm64.sha256
+            dist/microvm-darwin-amd64
+            dist/microvm-darwin-amd64.sha256
+            dist/microvm-darwin-arm64
+            dist/microvm-darwin-arm64.sha256
             dist/kube-microvm-operator-*.tgz
             dist/kube-microvm-operator-*.tgz.sha256
             dist/checksums.sha256

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ aws eks create-pod-identity-association \
 ### CLI
 
 ```bash
-# Detect architecture and install microvm binary
+# Detect OS and architecture, install microvm binary
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-curl -fsSL "https://github.com/codriverlabs/KubeMicroVM/releases/latest/download/microvm-linux-${ARCH}" \
+curl -fsSL "https://github.com/codriverlabs/KubeMicroVM/releases/latest/download/microvm-${OS}-${ARCH}" \
   -o ~/bin/microvm && chmod +x ~/bin/microvm
 ln -sf ~/bin/microvm ~/bin/kubectl-microvm
 

--- a/install_kube_microvm.sh
+++ b/install_kube_microvm.sh
@@ -182,6 +182,34 @@ check_prerequisites() {
     success "Prerequisites OK (arch: $ARCH_TAG)"
 }
 
+# ─── cert-manager check ───────────────────────────────────────────────────────
+ensure_cert_manager() {
+    step "Checking cert-manager"
+    if kubectl get crd certificates.cert-manager.io &>/dev/null; then
+        success "cert-manager CRDs found"
+        return
+    fi
+
+    warn "cert-manager is not installed — the operator chart requires Certificate and Issuer CRDs."
+    echo ""
+    echo "  Install cert-manager with:"
+    echo "    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml"
+    echo ""
+    read -rp "  Install cert-manager now? [Y/n] " answer
+    answer="${answer:-Y}"
+    if [[ "$answer" =~ ^[Yy] ]]; then
+        info "Installing cert-manager..."
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+        info "Waiting for cert-manager webhook to become ready..."
+        kubectl wait --for=condition=Available deployment/cert-manager-webhook \
+            -n cert-manager --timeout=120s
+        success "cert-manager installed"
+    else
+        error "cert-manager is required. Install it manually and re-run the installer."
+        exit 1
+    fi
+}
+
 # ─── Load/save config ─────────────────────────────────────────────────────────
 load_config() {
     mkdir -p "$CONFIG_DIR"
@@ -561,6 +589,7 @@ main() {
     if ! $CLI_ONLY; then
         import_images
         setup_iam
+        ensure_cert_manager
         discover_quotas
         install_operator
         install_auth_agent

--- a/operator-controller/src/main/helm/templates/_helpers.tpl
+++ b/operator-controller/src/main/helm/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Environment variables for the operator container.
+Iterates over app.envs (declared vars) and app.extraEnvs (user-injected vars).
+*/}}
+{{- define "kube-microvm-operator.envVars" -}}
+- name: KUBERNETES_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+{{- range $key, $val := .Values.app.envs }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- end }}
+{{- range $key, $val := .Values.extraEnvs }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- end }}
+{{- end }}

--- a/operator-controller/src/main/helm/values.yaml
+++ b/operator-controller/src/main/helm/values.yaml
@@ -11,6 +11,12 @@ fullnameOverride: ""
 # Set to your private ECR image when using a private registry:
 #   --set app.envs.MICROVM_AUTH_AGENT_IMAGE=123456789012.dkr.ecr.us-east-1.amazonaws.com/codriverlabs/kube-microvm-auth-agent:1.0.12
 
+# Additional environment variables (map of name: value).
+# Inject custom env vars not pre-declared in application.properties:
+#   helm install ... --set extraEnvs.AWS_ACCESS_KEY_ID=test
+#   helm install ... --set extraEnvs.MY_CUSTOM_VAR=foo
+# These are rendered as plain name/value env vars in the operator container.
+
 # AWS API quota guard — rate limits matching your account's service quotas.
 # These are passed to the operator as environment variables via app.envs.*
 # The install script auto-discovers actual values via `aws service-quotas get-service-quota`

--- a/operator-controller/src/main/resources/application.properties
+++ b/operator-controller/src/main/resources/application.properties
@@ -122,6 +122,13 @@ quarkus.helm.values.quotas.authTokenRate.paths=(kind == Deployment).spec.templat
 quarkus.helm.values.quotas.authTokenRate.value=45
 quarkus.helm.values.quotas.concurrentImageBuilds.paths=(kind == Deployment).spec.template.spec.containers.(name == kube-microvm-operator).env.(name == AWS_QUOTA_CONCURRENT_IMAGE_BUILDS).value
 quarkus.helm.values.quotas.concurrentImageBuilds.value=9
+# Auth-agent sidecar image — CI overrides with -Dquarkus.helm.values.authAgentImage.value=...:<version>
+quarkus.helm.values.authAgentImage.paths=(kind == Deployment).spec.template.spec.containers.(name == kube-microvm-operator).env.(name == MICROVM_AUTH_AGENT_IMAGE).value
+quarkus.helm.values.authAgentImage.value=ghcr.io/codriverlabs/microvm-auth-agent:latest
+# extraEnvs support — replace the env array with a range loop so arbitrary env vars
+# can be injected via --set app.extraEnvs.MY_VAR=value without pre-declaring them.
+quarkus.helm.expressions.0.path=(kind == Deployment).spec.template.spec.containers.(name == kube-microvm-operator).env
+quarkus.helm.expressions.0.expression={{- include "kube-microvm-operator.envVars" . | nindent 12 }}
 quarkus.micrometer.export.prometheus.path=/q/metrics
 # Disable ServiceMonitor generation — requires Prometheus Operator CRD which is not a hard dependency
 quarkus.kubernetes.prometheus.generate-service-monitor=false

--- a/operator-controller/src/main/resources/templates/NOTES.txt
+++ b/operator-controller/src/main/resources/templates/NOTES.txt
@@ -20,3 +20,17 @@ AWS IAM Setup:
     kubectl annotate serviceaccount kube-microvm-operator \
       -n {{ .Release.Namespace }} \
       eks.amazonaws.com/role-arn=arn:aws:iam::<ACCOUNT_ID>:role/kube-microvm-operator
+
+Enable MicroVM management in a namespace:
+  The operator only manages namespaces labelled with:
+    lambda.aws.amazon.com/manage-microvms=true
+
+  Label your namespace before creating MicroVM resources:
+    kubectl label namespace <YOUR-NAMESPACE> lambda.aws.amazon.com/manage-microvms=true
+
+  The 'default' namespace is labelled automatically by the installer.
+  Without this label, MicroVM CR creation will be rejected by the webhook.
+
+Custom environment variables:
+  To inject additional env vars into the operator (e.g. for emulator endpoints):
+    helm upgrade kube-microvm-operator ... --set extraEnvs.MY_VAR=value


### PR DESCRIPTION
## Summary

Addresses all four items in #52.

### Item 1: `--set app.envs.<newkey>` silently dropped

The Quarkus Helm extension generated individual env var references in the deployment template, silently ignoring unknown keys.

**Fix**: Use `quarkus.helm.expressions` to replace the env array with an `{{ include }}` of a `_helpers.tpl` named template that iterates over both `app.envs` (declared vars) and `extraEnvs` (user-injected vars).

Users can now inject arbitrary env vars:
```bash
helm install ... --set extraEnvs.AWS_ACCESS_KEY_ID=test --set extraEnvs.MY_VAR=foo
```

Also adds `quarkus.helm.values.authAgentImage` to properly parameterize the auth-agent image via the extension mechanism, eliminating the `sed` hack in CI.

### Item 2: cert-manager undocumented prerequisite

The installer now checks for cert-manager CRDs before helm install and offers to install it interactively if missing.

### Item 3: Namespace label easy to miss

NOTES.txt now reminds users to label namespaces with `lambda.aws.amazon.com/manage-microvms=true` and documents the `extraEnvs` feature.

### Item 4: macOS CLI builds

CI now produces darwin binaries for both amd64 (`macos-13`) and arm64 (`macos-14`). Release assets include all four platform binaries. README CLI install updated to auto-detect OS.

## Testing

- All 90 integration tests pass
- `helm template --set extraEnvs.MY_VAR=hello` correctly renders the injected env var
- Standard env vars (`app.envs.*`) continue to render via the range loop

Closes #52