### PR TITLE
chore(deps): upgrade AWS SDK, Quarkus, Maven, aws-crt, zstd-jni

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/operator-cli/pom.xml
+++ b/operator-cli/pom.xml
@@ -75,11 +75,11 @@
         <!-- aws-crt is an optional dependency of aws-sdk checksums but has hard bytecode references
              to CRC64NVME/CRC32C/XXHash that GraalVM's static analysis resolves at build time.
              Must be on the classpath for native image compilation. Version must match what
-             aws-sdk 2.44.6 was compiled against (awscrt.version=0.45.1 in aws-sdk-java-pom). -->
+             aws-sdk 2.53.0 was compiled against (awscrt.version in aws-sdk-java-pom). -->
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.48.3</version>
+            <version>0.48.4</version>
         </dependency>
 
         <!-- Quarkus Picocli -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>3.38.1</quarkus.platform.version>
-        <aws.sdk.version>2.51.2</aws.sdk.version>
+        <quarkus.platform.version>3.38.2</quarkus.platform.version>
+        <aws.sdk.version>2.53.0</aws.sdk.version>
         <jackson.version>2.22.1</jackson.version>
         <fabric8.version>7.8.0</fabric8.version>
         <josdk.version>5.5.1</josdk.version>
@@ -133,7 +133,7 @@
             <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
-                <version>1.5.7-12</version>
+                <version>1.5.7-13</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Dependency Upgrades

| Dependency | From | To |
|-----------|------|-----|
| AWS SDK | 2.51.2 | 2.53.0 |
| Quarkus Platform | 3.38.1 | 3.38.2 |
| aws-crt | 0.48.3 | 0.48.4 |
| zstd-jni | 1.5.7-12 | 1.5.7-13 |
| Maven | 3.9.10 | 3.9.16 |
| Maven Wrapper | 3.3.2 | 3.3.4 |

## Testing

- All 90 integration tests pass
- Native build (operator, CLI, auth-agent) compiles successfully
- aws-crt 0.48.4 is compatible with AWS SDK 2.53.0

Supersedes Dependabot PRs #70, #71, #72, #73, #74, #75.