### PR TITLE
fix+feat: PRO release hooks — env var fix, helm artifact, platform-versions, notify-pro

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -64,7 +64,46 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # ─── Native CLI binary ────────────────────────────────────────────────────
+  # ─── Platform versions artifact ──────────────────────────────────────────
+  # Generates platform-versions.properties and uploads it as a workflow artifact
+  # so the release job can attach it to the GitHub Release and the notify-pro job
+  # can pass the version to KubeMicroVM-PRO's community-update workflow.
+
+  platform-versions:
+    name: Platform Versions
+    needs: test-jvm
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Generate platform-versions.properties
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          QUARKUS_VERSION=$(grep '<quarkus.platform.version>' pom.xml \
+            | sed 's/.*<quarkus.platform.version>\(.*\)<\/quarkus.platform.version>.*/\1/' | tr -d ' ')
+          AWS_SDK=$(grep '<aws.sdk.version>' pom.xml \
+            | sed 's/.*<aws.sdk.version>\(.*\)<\/aws.sdk.version>.*/\1/' | tr -d ' ')
+          JAVA_VERSION=$(grep '<maven.compiler.release>' pom.xml \
+            | sed 's/.*<maven.compiler.release>\(.*\)<\/maven.compiler.release>.*/\1/' | tr -d ' ')
+          cat > platform-versions.properties <<EOF
+          community.version=${VERSION}
+          quarkus.platform.version=${QUARKUS_VERSION}
+          aws.sdk.version=${AWS_SDK}
+          java.version=${JAVA_VERSION}
+          EOF
+          # Strip leading whitespace from heredoc indentation
+          sed -i 's/^[[:space:]]*//' platform-versions.properties
+          echo "Generated platform-versions.properties:"
+          cat platform-versions.properties
+      - uses: actions/upload-artifact@v7
+        with:
+          name: platform-versions
+          path: platform-versions.properties
+          retention-days: 7
+
+
 
   native-cli:
     name: Native CLI (${{ matrix.arch }})
@@ -279,7 +318,7 @@ jobs:
 
   release:
     name: GitHub Release
-    needs: [native-cli, manifest, helm-chart]
+    needs: [native-cli, manifest, helm-chart, platform-versions]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
@@ -303,15 +342,19 @@ jobs:
         with:
           name: helm-chart
           path: dist/
+      - uses: actions/download-artifact@v8
+        with:
+          name: platform-versions
+          path: dist/
       - name: Generate checksums
         working-directory: dist
         run: |
           # Individual .sha256 per artifact
-          for f in microvm-linux-amd64 microvm-linux-arm64 microvm-darwin-arm64 kube-microvm-operator-*.tgz; do
+          for f in microvm-linux-amd64 microvm-linux-arm64 microvm-darwin-arm64 kube-microvm-operator-*.tgz platform-versions.properties; do
             sha256sum "$f" > "$f.sha256"
           done
           # Combined checksums.sha256
-          sha256sum microvm-linux-amd64 microvm-linux-arm64 microvm-darwin-arm64 kube-microvm-operator-*.tgz > checksums.sha256
+          sha256sum microvm-linux-amd64 microvm-linux-arm64 microvm-darwin-arm64 kube-microvm-operator-*.tgz platform-versions.properties > checksums.sha256
       - uses: actions/checkout@v7
         with:
           path: repo
@@ -337,8 +380,54 @@ jobs:
             dist/microvm-darwin-arm64.sha256
             dist/kube-microvm-operator-*.tgz
             dist/kube-microvm-operator-*.tgz.sha256
+            dist/platform-versions.properties
+            dist/platform-versions.properties.sha256
             dist/checksums.sha256
             install_kube_microvm.sh.sha256
             kube-microvm-operator-role.yaml.sha256
             repo/install_kube_microvm.sh
             repo/iam/kube-microvm-operator-role.yaml
+
+  # ─── Notify PRO of Community release ─────────────────────────────────────
+  # Triggers KubeMicroVM-PRO's community-update.yml workflow, which validates
+  # PRO compatibility against the newly published Community jars.
+  #
+  # Fires on every release tag (including RC/beta/alpha) so PRO can catch
+  # breaking changes before GA. GA releases also update PRO's pinned version.
+  #
+  # Requires a fine-grained PAT or classic PAT with contents:write on
+  # plasticity-of-cloud/KubeMicroVM-PRO stored as secret PRO_DISPATCH_TOKEN.
+
+  notify-pro:
+    name: Notify KubeMicroVM-PRO
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch community-release event to KubeMicroVM-PRO
+        env:
+          PRO_DISPATCH_TOKEN: ${{ secrets.PRO_DISPATCH_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ -z "${PRO_DISPATCH_TOKEN}" ]]; then
+            echo "::warning::PRO_DISPATCH_TOKEN is not set — skipping KubeMicroVM-PRO notification."
+            echo "Add a fine-grained PAT with contents:write on plasticity-of-cloud/KubeMicroVM-PRO"
+            echo "as repository secret PRO_DISPATCH_TOKEN to enable automatic PRO validation."
+            exit 0
+          fi
+          HTTP_STATUS=$(curl -s -o /tmp/dispatch-response.json -w "%{http_code}" \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${PRO_DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/plasticity-of-cloud/KubeMicroVM-PRO/dispatches \
+            -d "{\"event_type\":\"community-release\",\"client_payload\":{\"version\":\"${VERSION}\"}}")
+          if [[ "${HTTP_STATUS}" == "204" ]]; then
+            echo "✅ Dispatched community-release event to KubeMicroVM-PRO for v${VERSION}"
+          else
+            echo "::error::Dispatch failed with HTTP ${HTTP_STATUS}"
+            cat /tmp/dispatch-response.json
+            exit 1
+          fi

--- a/docs/design/pro-artifact-consumability.md
+++ b/docs/design/pro-artifact-consumability.md
@@ -1,0 +1,273 @@
+# PRO Artifact Consumability — Jandex Indexes and Helm Value Mappings
+
+**Status**: Design
+**Scope**: `codriverlabs/KubeMicroVM` (Community)
+**Driven by**: `KubeMicroVM-PRO/docs/design/build-publish-open-gaps.md` (G0, G18) and
+`build-and-publish-pipeline.md` §7.4, §7.6
+**Branch**: `feature/pro-consumability`
+
+---
+
+## 1. Motivation
+
+Community is the producer in a two-repository edition model. PRO consumes our published
+Maven jars and augments them inside its own Quarkus application (`operator-pro-dist`),
+overlaying CDI `@Alternative @Priority(100)` beans onto our `Default*` SPI
+implementations. Our release is therefore a **published API**, and two of its properties
+are currently broken in ways our own build cannot detect.
+
+This document covers two independent defects. Both are cheap to fix and both are
+verifiable in this repository.
+
+### 1.1 Defect A — `operator-controller` and `operator-spi` publish no Jandex index
+
+ArC only scans a dependency jar for CDI beans if that jar carries `META-INF/jandex.idx`,
+a `beans.xml` marker, or is explicitly named in a consumer's
+`quarkus.index-dependency.*`.
+
+Current state in this repository:
+
+| Module | `jandex-maven-plugin` | Contains |
+|---|---|---|
+| `operator-core` | declared (`pom.xml:21`) | CRD models |
+| `operator-webhook` | declared (`pom.xml:107`) | webhook handlers |
+| `operator-spi` | **absent** | SPI interfaces |
+| `operator-controller` | **absent** | **all reconcilers + all `Default*` SPI beans** |
+
+`operator-controller` is our *application* module. In our own build Quarkus indexes it as
+the root application, so no index is needed and none is produced — which is precisely why
+this is invisible to us.
+
+**Consequence for PRO** — the PRO distribution was built containing *only* the PRO
+gateway reconciler. No `MicroVMReconciler`, no `MicroVMImageReconciler`, no
+`MicroVMReplicaSetReconciler`, no `MicroVMNetworkReconciler`. The overlay was broken in
+both directions: `DefaultImageRefResolver`, `DefaultQuotaPolicy`, `DefaultTenantResolver`,
+`DefaultTokenPolicy` and `DefaultOperatorExtension` all live in `operator-controller`, so
+the PRO `@Alternative` beans had no Community defaults to override.
+
+Nothing failed loudly. CDI resolution was satisfied, the build was green, and PRO's unit
+tests construct the `Pro*` beans directly.
+
+PRO currently works around this with `quarkus.index-dependency` entries in
+`operator-pro-dist/src/main/resources/application.properties:28-31`. Those entries are
+load-bearing: remove them, rename a module, or change Quarkus indexing behaviour and the
+regression returns silently. The workaround is also invisible from our side, so a refactor
+here cannot know it is depended upon.
+
+### 1.2 Defect B — `quarkus.helm.values.*` mappings into the operator `env` array are inert
+
+This one affects **our own releases**, not just PRO.
+
+`application.properties:130-131` replaces the operator container's entire `env` array
+with an include of the `envVars` helper:
+
+```properties
+quarkus.helm.expressions.0.path=(kind == Deployment)...containers.(name == kube-microvm-operator).env
+quarkus.helm.expressions.0.expression={{- include "kube-microvm-operator.envVars" . | nindent 12 }}
+```
+
+The helper (`src/main/helm/templates/_helpers.tpl`) iterates `.Values.app.envs` and
+`.Values.extraEnvs`. Any `quarkus.helm.values.<name>.paths` expression pointing *inside*
+that array therefore targets a structure that no longer exists in the rendered template.
+
+Two groups of mappings are affected. Verified against the generated chart in
+`operator-controller/target/helm/kubernetes/kube-microvm-operator/`:
+
+**B1 — auth-agent image (`application.properties:126-127`)**
+
+The value *is* emitted into `values.yaml`, but under `app.authAgentImage`, and no template
+references it. The rendered env var comes from `app.envs`:
+
+```yaml
+app:
+  authAgentImage: ghcr.io/codriverlabs/microvm-auth-agent:7.7.7   # dead — no template reads this
+  envs:
+    MICROVM_AUTH_AGENT_IMAGE: ghcr.io/codriverlabs/microvm-auth-agent:latest   # what actually renders
+```
+
+`native-build.yml:264` overrides `quarkus.helm.values.authAgentImage.value` per release.
+That override lands in the dead key. **Every released Community chart pins the auth-agent
+sidecar to `:latest`.** A `v1.0.15` install gets whatever `:latest` happens to be at
+install time, which defeats version-matched deployment and makes rollback
+non-deterministic.
+
+**B2 — quota rate limits (`application.properties:111-123`)**
+
+Worse: these produce no `values.yaml` key at all. There is no `quotas` key in the
+generated `values.yaml`, and no template reference.
+
+The `AWS_QUOTA_*` values that *do* render come from Quarkus's automatic detection of
+`${VAR:default}` config expressions, so they carry the **code defaults**, not the values
+in these mappings:
+
+| Env var | Intended (`helm.values.quotas.*`) | Actually rendered | AWS burst limit |
+|---|---|---|---|
+| `AWS_QUOTA_RUN_MICROVM_RATE` | 4 | **5** | 5/s |
+| `AWS_QUOTA_TERMINATE_MICROVM_RATE` | 9 | **10** | 10/s |
+| `AWS_QUOTA_SUSPEND_MICROVM_RATE` | 1 | **2** | 2/s |
+| `AWS_QUOTA_RESUME_MICROVM_RATE` | 4 | **5** | 5/s |
+| `AWS_QUOTA_AUTH_TOKEN_RATE` | 45 | **50** | 50/s |
+| `AWS_QUOTA_CONCURRENT_IMAGE_BUILDS` | 9 | **10** | 10 |
+
+The intent of the mappings is clear from the numbers: each sits one below the
+corresponding AWS burst limit, giving the quota guard headroom. Because they never
+applied, the shipped chart configures the guard **exactly at** the AWS burst rate, so the
+guard permits traffic right up to the throttling threshold rather than just below it.
+
+This is consistent with the load-test observation recorded in the README: 50 concurrent
+`CreateMicrovmAuthToken` requests returned 0% success against a 50/s burst limit.
+
+Whether to adopt the intended headroom defaults is a product decision and is **out of
+scope for this change** — see §4.
+
+---
+
+## 2. Design
+
+### 2.1 Jandex indexes
+
+Add `jandex-maven-plugin` to `operator-spi` and `operator-controller`, and move the
+version into the parent `pluginManagement` so all four indexed modules share one
+declaration. `operator-core` and `operator-webhook` currently hardcode `3.6.0`
+independently.
+
+Adding the plugin to `operator-controller` — a Quarkus application module — only writes
+`META-INF/jandex.idx` into the classes jar. It does not change how Quarkus augments this
+module in our own build, where the module is the application root and is indexed
+regardless. This must be verified against the native build, not just the JVM build.
+
+`operator-spi` is pure interfaces with no CDI beans, so an index there is defensive rather
+than strictly required. It is included because PRO names it in `index-dependency` and
+because an unindexed jar is a trap for any future consumer.
+
+Once a release ships with indexes and PRO bumps `<community.version>` past it, PRO's
+`index-dependency` entries become redundant. They are harmless in that state and PRO
+should keep them until the bump lands.
+
+### 2.2 Helm value mappings
+
+Delete the inert mappings and drive the auth-agent image through the surface the helper
+actually iterates.
+
+| Mapping | Action |
+|---|---|
+| `quarkus.helm.values.authAgentImage.*` | delete — replaced by `quarkus.kubernetes.env.vars.MICROVM_AUTH_AGENT_IMAGE` |
+| `quarkus.helm.values.quotas.*` (6 entries, 12 lines) | delete — inert, and the effective defaults already come from code |
+| `quarkus.helm.values.crdValidatingRoleName.*` | **keep** — targets `metadata.name` / `roleRef.name`, not the env array |
+| `quarkus.helm.values.replicas.*` | **keep** — targets `spec.replicas`, not the env array |
+
+`native-build.yml` changes from
+
+```
+-Dquarkus.helm.values.authAgentImage.value=ghcr.io/codriverlabs/microvm-auth-agent:${VERSION}
+```
+
+to
+
+```
+-Dquarkus.kubernetes.env.vars.MICROVM_AUTH_AGENT_IMAGE=ghcr.io/codriverlabs/microvm-auth-agent:${VERSION}
+```
+
+which lands in `values.yaml` under `app.envs.MICROVM_AUTH_AGENT_IMAGE` — the key the
+helper reads, and the key already documented for install-time override in
+`src/main/helm/values.yaml`. This is the same mechanism PRO uses for `PRO_GATEWAY_IMAGE`,
+verified there in both directions (CI bake and `--set`).
+
+The user-facing override contract is unchanged:
+
+```bash
+--set app.envs.MICROVM_AUTH_AGENT_IMAGE=<repo>:<tag>
+```
+
+### 2.3 Rule for future env vars
+
+Any operator env var that must be overridable at chart build time or install time is
+declared with `quarkus.kubernetes.env.vars.<NAME>`, never with a
+`quarkus.helm.values.*.paths` expression pointing inside the container `env` array. The
+`expressions.0` replacement makes the latter silently inert.
+
+---
+
+## 3. Testing strategy
+
+Both defects shipped green, so each fix needs an assertion that fails without it.
+
+**Jandex** — assert the index is present in the built jars:
+
+```bash
+for m in operator-core operator-spi operator-controller operator-webhook; do
+  unzip -l "$m/target/$m-"*.jar | grep -q 'META-INF/jandex.idx' \
+    || { echo "MISSING jandex index: $m"; exit 1; }
+done
+```
+
+**Helm mappings** — assert the rendered env var carries the baked version, not `:latest`:
+
+```bash
+mvn -pl operator-controller package -DskipTests \
+  -Dquarkus.helm.enabled=true \
+  -Dquarkus.kubernetes.env.vars.MICROVM_AUTH_AGENT_IMAGE=ghcr.io/codriverlabs/microvm-auth-agent:9.9.9
+CHART=operator-controller/target/helm/kubernetes/kube-microvm-operator
+grep -q 'microvm-auth-agent:9.9.9' "$CHART/values.yaml"
+helm template t "$CHART" | grep -A1 MICROVM_AUTH_AGENT_IMAGE | grep -q '9.9.9'
+```
+
+Also assert install-time override still works, and that no dead keys remain:
+
+```bash
+helm template t "$CHART" --set app.envs.MICROVM_AUTH_AGENT_IMAGE=my.registry/agent:5.5.5 \
+  | grep -q 'my.registry/agent:5.5.5'
+grep -q 'authAgentImage' "$CHART/values.yaml" && { echo "dead key still emitted"; exit 1; }
+```
+
+**Regression suite** — `./mvnw -pl operator-tests verify` must stay green. The native
+build must also be verified per `.kiro/steering/build-test-requirements.md`, since the
+Jandex change touches how a Quarkus application module is packaged and native-image
+failures do not surface in JVM mode.
+
+**E2E** — install the chart on the EKS test cluster and confirm the injected sidecar
+image tag matches the chart version rather than `latest`.
+
+---
+
+## 4. Out of scope
+
+- **Quota default values.** §1.2 B2 establishes that the shipped defaults sit at the AWS
+  burst limit rather than one below it, and that the one-below values were the original
+  intent. Changing them alters throttling behaviour for every existing installation and
+  should be a deliberate, separately tested decision. This change only removes the
+  mappings that never worked; effective defaults are unchanged.
+- **Publishing `src/main/helm/` as a consumable artifact** (PRO G17). PRO currently
+  vendors three of our four overlay files and they drift on every `<community.version>`
+  bump. Separate change.
+- **`platform-versions.properties` release asset** and the **`notify-pro`
+  `repository_dispatch` job**. Separate change; both are additive workflow steps.
+- **`AWS_QUOTA_DISCOVERY` vs `AWS_QUOTA_DISCOVERY_ENABLED`.** The generated chart emits
+  the former; `src/main/helm/values.yaml` documents the latter. Documentation defect,
+  noted here so it is not lost.
+
+---
+
+## 5. Compatibility
+
+Both changes are backward compatible for chart consumers.
+
+- No `values.yaml` key that any template reads is removed. `app.authAgentImage` and the
+  absent `quotas` tree were never consumable.
+- `--set app.envs.MICROVM_AUTH_AGENT_IMAGE=...` behaves exactly as before, and as already
+  documented.
+- Anyone passing `-Dquarkus.helm.values.authAgentImage.value=...` in their own build
+  loses a flag that had no effect. `native-build.yml` is the only known caller.
+
+The auth-agent fix changes released behaviour in the intended direction: charts will pin
+the sidecar to the release version instead of `:latest`.
+
+---
+
+## 6. References
+
+- `KubeMicroVM-PRO/docs/design/build-publish-open-gaps.md` — G0, G18
+- `KubeMicroVM-PRO/docs/design/build-and-publish-pipeline.md` — §7.4 (CDI across the jar
+  boundary), §7.6 (`helm.values` cannot target the env array)
+- `.kiro/steering/build-test-requirements.md` — pre-push verification, native build
+  rationale

--- a/docs/design/pro-artifact-consumability.md
+++ b/docs/design/pro-artifact-consumability.md
@@ -242,7 +242,10 @@ image tag matches the chart version rather than `latest`.
   bump. Separate change.
 - **`platform-versions.properties` release asset** and the **`notify-pro`
   `repository_dispatch` job**. Separate change; both are additive workflow steps.
-- **`AWS_QUOTA_DISCOVERY` vs `AWS_QUOTA_DISCOVERY_ENABLED`.** The generated chart emits
+- **`AWS_QUOTA_DISCOVERY` vs `AWS_QUOTA_DISCOVERY_ENABLED`.** Fixed in `feature/pro-release-hooks`.
+  `application.properties` now binds `${AWS_QUOTA_DISCOVERY_ENABLED:false}`, matching
+  `values.yaml`. The install script's `--set quotas.*` args were also corrected to
+  `--set-string app.envs.AWS_QUOTA_*` (the `quotas.*` paths never existed in the chart).
   the former; `src/main/helm/values.yaml` documents the latter. Documentation defect,
   noted here so it is not lost.
 

--- a/docs/testing/uat-quota-discovery.md
+++ b/docs/testing/uat-quota-discovery.md
@@ -10,7 +10,7 @@
 ## What Was Tested
 
 Runtime quota discovery: operator queries AWS Service Quotas API at startup
-when `AWS_QUOTA_DISCOVERY=true` (Helm: `--set-string app.envs.AWS_QUOTA_DISCOVERY=true`).
+when `AWS_QUOTA_DISCOVERY_ENABLED=true` (Helm: `--set-string app.envs.AWS_QUOTA_DISCOVERY_ENABLED=true`).
 
 Requires IAM permission `service-quotas:GetServiceQuota` on the operator role.
 
@@ -24,7 +24,7 @@ on the `kube-microvm-operator` IAM role.
 Deployed with:
 ```bash
 helm upgrade kube-microvm-operator <chart> \
-  --set-string "app.envs.AWS_QUOTA_DISCOVERY=true"
+  --set-string "app.envs.AWS_QUOTA_DISCOVERY_ENABLED=true"
 ```
 
 ---

--- a/install_kube_microvm.sh
+++ b/install_kube_microvm.sh
@@ -463,13 +463,16 @@ install_operator() {
     [[ -n "$ROLE_ARN" ]] && HELM_ARGS="$HELM_ARGS --set serviceAccount.roleArn=${ROLE_ARN}"
 
     # Quota overrides — only set if explicitly provided (populated by discover_quotas())
-    [[ -n "$QUOTA_RUN_MICROVM_RATE" ]]        && HELM_ARGS="$HELM_ARGS --set quotas.runMicrovmRate=${QUOTA_RUN_MICROVM_RATE}"
-    [[ -n "$QUOTA_TERMINATE_MICROVM_RATE" ]]  && HELM_ARGS="$HELM_ARGS --set quotas.terminateMicrovmRate=${QUOTA_TERMINATE_MICROVM_RATE}"
-    [[ -n "$QUOTA_SUSPEND_MICROVM_RATE" ]]    && HELM_ARGS="$HELM_ARGS --set quotas.suspendMicrovmRate=${QUOTA_SUSPEND_MICROVM_RATE}"
-    [[ -n "$QUOTA_RESUME_MICROVM_RATE" ]]     && HELM_ARGS="$HELM_ARGS --set quotas.resumeMicrovmRate=${QUOTA_RESUME_MICROVM_RATE}"
-    [[ -n "$QUOTA_AUTH_TOKEN_RATE" ]]         && HELM_ARGS="$HELM_ARGS --set quotas.authTokenRate=${QUOTA_AUTH_TOKEN_RATE}"
-    [[ -n "$QUOTA_CONCURRENT_IMAGE_BUILDS" ]] && HELM_ARGS="$HELM_ARGS --set quotas.concurrentImageBuilds=${QUOTA_CONCURRENT_IMAGE_BUILDS}"
-    $QUOTA_DISCOVERY_RUNTIME                  && HELM_ARGS="$HELM_ARGS --set quotas.discoveryEnabled=true"
+    # These inject env vars into the operator container via app.envs.*.
+    # Do NOT use --set quotas.* — those paths were removed; see
+    # docs/design/pro-artifact-consumability.md
+    [[ -n "$QUOTA_RUN_MICROVM_RATE" ]]        && HELM_ARGS="$HELM_ARGS --set-string app.envs.AWS_QUOTA_RUN_MICROVM_RATE=${QUOTA_RUN_MICROVM_RATE}"
+    [[ -n "$QUOTA_TERMINATE_MICROVM_RATE" ]]  && HELM_ARGS="$HELM_ARGS --set-string app.envs.AWS_QUOTA_TERMINATE_MICROVM_RATE=${QUOTA_TERMINATE_MICROVM_RATE}"
+    [[ -n "$QUOTA_SUSPEND_MICROVM_RATE" ]]    && HELM_ARGS="$HELM_ARGS --set-string app.envs.AWS_QUOTA_SUSPEND_MICROVM_RATE=${QUOTA_SUSPEND_MICROVM_RATE}"
+    [[ -n "$QUOTA_RESUME_MICROVM_RATE" ]]     && HELM_ARGS="$HELM_ARGS --set-string app.envs.AWS_QUOTA_RESUME_MICROVM_RATE=${QUOTA_RESUME_MICROVM_RATE}"
+    [[ -n "$QUOTA_AUTH_TOKEN_RATE" ]]         && HELM_ARGS="$HELM_ARGS --set-string app.envs.AWS_QUOTA_AUTH_TOKEN_RATE=${QUOTA_AUTH_TOKEN_RATE}"
+    [[ -n "$QUOTA_CONCURRENT_IMAGE_BUILDS" ]] && HELM_ARGS="$HELM_ARGS --set-string app.envs.AWS_QUOTA_CONCURRENT_IMAGE_BUILDS=${QUOTA_CONCURRENT_IMAGE_BUILDS}"
+    $QUOTA_DISCOVERY_RUNTIME                  && HELM_ARGS="$HELM_ARGS --set-string app.envs.AWS_QUOTA_DISCOVERY_ENABLED=true"
 
     run "helm upgrade --install kube-microvm-operator $CHART $HELM_ARGS"
     success "kube-microvm-operator installed"

--- a/operator-controller/pom.xml
+++ b/operator-controller/pom.xml
@@ -218,6 +218,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Publish Helm overlay files as a Maven artifact so KubeMicroVM-PRO can
+                 declare a versioned dependency instead of vendoring them manually.
+                 Artifact: ai.codriverlabs:operator-controller:<version>:zip:helm-templates
+                 PRO consumers: use maven-dependency-plugin:unpack to extract.
+                 See docs/design/pro-artifact-consumability.md (PRO G17). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.7.1</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/helm-templates.xml</descriptor>
+                    </descriptors>
+                    <appendAssemblyId>true</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>helm-templates-zip</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/operator-controller/src/main/assembly/helm-templates.xml
+++ b/operator-controller/src/main/assembly/helm-templates.xml
@@ -1,0 +1,33 @@
+<!--
+  Assembly descriptor for the operator-controller helm-templates artifact.
+
+  Packages src/main/helm/ as a zip with classifier "helm-templates":
+    ai.codriverlabs:operator-controller:<version>:zip:helm-templates
+
+  Consumers (KubeMicroVM-PRO) can declare this as a dependency and unpack it
+  with maven-dependency-plugin:unpack instead of vendoring the overlay files
+  directly, eliminating drift on every <community.version> bump.
+
+  Published automatically alongside the jar as part of `mvn deploy`.
+  See docs/design/pro-artifact-consumability.md (PRO G17).
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0
+                              https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>helm-templates</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <!-- No top-level directory wrapper — contents unpack directly at the target path -->
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/helm</directory>
+            <outputDirectory>.</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/operator-controller/src/main/resources/application.properties
+++ b/operator-controller/src/main/resources/application.properties
@@ -17,7 +17,7 @@ aws.quota.auth-token-rate=${AWS_QUOTA_AUTH_TOKEN_RATE:50}
 aws.quota.shell-auth-token-rate=${AWS_QUOTA_SHELL_AUTH_TOKEN_RATE:5}
 aws.quota.concurrent-image-builds=${AWS_QUOTA_CONCURRENT_IMAGE_BUILDS:10}
 aws.quota.token-queue-size=${AWS_QUOTA_TOKEN_QUEUE_SIZE:200}
-aws.quota.discovery.enabled=${AWS_QUOTA_DISCOVERY:false}
+aws.quota.discovery.enabled=${AWS_QUOTA_DISCOVERY_ENABLED:false}
 aws.microvm.endpoint=${AWS_MICROVM_ENDPOINT:}
 aws.sts.endpoint=${AWS_ENDPOINT_URL_STS:}
 


### PR DESCRIPTION
## Summary

Three deferred items from `docs/design/pro-artifact-consumability.md §4`, addressed on `feature/pro-release-hooks`.

---

### fix: AWS_QUOTA_DISCOVERY → AWS_QUOTA_DISCOVERY_ENABLED (`d8aca09`)

**application.properties**: Renames the env var binding from `${AWS_QUOTA_DISCOVERY:false}` to `${AWS_QUOTA_DISCOVERY_ENABLED:false}`. The generated chart now emits `AWS_QUOTA_DISCOVERY_ENABLED` in `values.yaml`, matching the documented example that was already there on line 35.

**install_kube_microvm.sh**: All `--set quotas.*` args (broken since `feature/pro-consumability` removed those helm paths) corrected to `--set-string app.envs.AWS_QUOTA_*` — the actual chart structure.

**Docs updated**: `docs/testing/uat-quota-discovery.md`

---

### feat: Helm overlay files as Maven artifact (`83b9083`)

Adds `maven-assembly-plugin` to `operator-controller` that packages `src/main/helm/` as a classified zip artifact, published automatically alongside the jar:

```
ai.codriverlabs:operator-controller:<version>:zip:helm-templates
```

Zip contents:
- `templates/_helpers.tpl`
- `templates/validating-clusterrolebinding.yaml`
- `crds/microvmclasses.lambda.aws.amazon.com-v1.yml`
- `values.yaml`

No CI changes required — `operator-controller` is already in the `publish-maven` job. Addresses PRO G17: PRO can now declare a versioned dependency and unpack instead of vendoring files manually.

---

### feat: platform-versions.properties + notify-pro dispatch (`fe49b47`)

**platform-versions.properties**: New `platform-versions` CI job generates a properties file from pom.xml on every tag push and attaches it to the GitHub Release (with checksum).

```properties
community.version=1.0.16
quarkus.platform.version=3.39.1
aws.sdk.version=2.54.7
java.version=25
```

**notify-pro**: New `notify-pro` job fires after `release`, sends a `repository_dispatch` (`community-release` event) to `plasticity-of-cloud/KubeMicroVM-PRO`, triggering PRO's existing `community-update.yml` workflow. Requires `PRO_DISPATCH_TOKEN` secret — degrades gracefully with a warning if absent (can be wired up later).

---

## Testing

- `./mvnw -pl operator-tests verify`: **90 tests, 0 failures**
- Generated chart emits `AWS_QUOTA_DISCOVERY_ENABLED` (verified in `target/helm/.../values.yaml`)
- `operator-controller-1.1.0-SNAPSHOT-helm-templates.zip` produced and contents verified