### PR TITLE
fix: add namespaces list and secrets RBAC for CaSecretReplicator

### DIFF
--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/ca/CaSecretReplicator.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/ca/CaSecretReplicator.java
@@ -33,6 +33,13 @@ import java.util.concurrent.TimeUnit;
  * Rotation: this component runs periodically and on namespace events to ensure
  * the CA Secret stays in sync. Kubernetes automatically propagates Secret changes
  * to mounted volumes within ~60-120 seconds.
+ *
+ * <p>Required RBAC (cluster-scoped, declared on MicroVMReconciler via @AdditionalRBACRules):
+ * <ul>
+ *   <li>{@code "" / namespaces: get, list, watch} — to discover managed namespaces</li>
+ *   <li>{@code "" / secrets: get, list, create, update} in managed namespaces — to replicate CA Secret</li>
+ * </ul>
+ * See docs/design/uat-failure-analysis-rc2.md RC-1.
  */
 @ApplicationScoped
 public class CaSecretReplicator {

--- a/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMReconciler.java
+++ b/operator-controller/src/main/java/ai/codriverlabs/microvm/operator/controller/reconciler/MicroVMReconciler.java
@@ -44,6 +44,20 @@ import java.util.concurrent.TimeUnit;
         apiGroups = "lambda.aws.amazon.com",
         resources = {"microvmtemplates", "microvmnetworks", "microvmimages"},
         verbs = {"get", "list", "watch"}
+    ),
+    // CaSecretReplicator: list all namespaces to find managed ones, then replicate CA Secret.
+    // Without namespaces list the replicator fails silently every 5 minutes.
+    // See docs/design/uat-failure-analysis-rc2.md RC-1.
+    @io.quarkiverse.operatorsdk.annotations.RBACRule(
+        apiGroups = "",
+        resources = {"namespaces"},
+        verbs = {"get", "list", "watch"}
+    ),
+    // CaSecretReplicator: create/update the CA Secret in each managed namespace.
+    @io.quarkiverse.operatorsdk.annotations.RBACRule(
+        apiGroups = "",
+        resources = {"secrets"},
+        verbs = {"get", "list", "create", "update"}
     )
 })
 public class MicroVMReconciler implements Reconciler<MicroVM>, Cleaner<MicroVM> {


### PR DESCRIPTION
## Problem

`CaSecretReplicator.syncAll()` lists all namespaces to find managed ones, then creates/updates the CA certificate Secret in each. The operator's ClusterRole was missing both permissions, producing a 403 every 5 minutes:

```
ERROR [CaSecretReplicator] Failed to sync CA Secrets to managed namespaces:
  namespaces is forbidden: ... cannot list resource "namespaces" at the cluster scope
```

Without this, the CA Secret is never replicated to managed namespaces. This directly blocks the PRO `MicroVMGatewayReconciler` from creating a namespace-scoped cert-manager Issuer, which is required for gateway TLS.

See: `KubeMicroVM-PRO/docs/design/uat-failure-analysis-rc2.md` RC-1.

## Changes

Adds to `MicroVMReconciler @AdditionalRBACRules`:
- `"" / namespaces: get, list, watch` — cluster-scoped, required by `namespaces().list()`
- `"" / secrets: get, list, create, update` — replicate CA Secret to managed namespaces

## Testing

- 90 unit/integration tests pass
- Generated `microvmreconciler-cluster-role` verified to contain both new rules