### PR TITLE
feat: add ClusterIssuer to Helm chart for cross-namespace gateway TLS

### DIFF
--- a/operator-controller/pom.xml
+++ b/operator-controller/pom.xml
@@ -206,7 +206,8 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Override JOSDK's validating-clusterrolebinding.yaml to reference the renamed role -->
+            <!-- Override JOSDK's validating-clusterrolebinding.yaml to reference the renamed role,
+                 and add the ClusterIssuer for cross-namespace gateway TLS (RC-2 fix). -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -223,6 +224,7 @@
                                     <directory>src/main/helm/templates</directory>
                                     <includes>
                                         <include>validating-clusterrolebinding.yaml</include>
+                                        <include>cluster-issuer.yaml</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/operator-controller/src/main/helm/templates/cluster-issuer.yaml
+++ b/operator-controller/src/main/helm/templates/cluster-issuer.yaml
@@ -1,0 +1,35 @@
+{{/*
+  ClusterIssuer backed by the operator CA certificate.
+
+  This is a cluster-scoped cert-manager Issuer that allows gateway reconcilers
+  in ANY namespace to issue TLS certificates without requiring a per-namespace
+  Issuer setup. The underlying CA Secret lives in the operator namespace
+  (kube-microvm) and was created by the namespace-scoped CA chain during install.
+
+  Name: kube-microvm-operator-ca (same as the namespace Issuer, different scope)
+
+  Why ClusterIssuer in addition to the existing namespace Issuer:
+  - The MicroVMGateway reconciler (PRO) deploys proxy Deployments into workload
+    namespaces (e.g. e2e-session, production). cert-manager requires the referenced
+    Issuer to exist in the same namespace as the Certificate, or to be a ClusterIssuer.
+  - Creating a per-namespace Issuer for every managed namespace is possible but
+    requires the CA Secret to be replicated there first (CaSecretReplicator). The
+    ClusterIssuer avoids this dependency and is simpler for the default case.
+  - Per-namespace Issuer (opt-in isolation) is tracked as a PRO roadmap item:
+    docs/design/gateway-tls-namespace-isolation.md
+
+  Roadmap: PRO will add opt-in per-namespace Issuer support once the ClusterIssuer
+  path is proven stable. See PRO docs/design/gateway-tls-namespace-isolation.md.
+*/}}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: kube-microvm-operator-ca
+  labels:
+    app.kubernetes.io/name: kube-microvm-operator
+    app.kubernetes.io/component: pki
+    app.kubernetes.io/managed-by: kube-microvm-operator
+spec:
+  ca:
+    secretName: kube-microvm-operator-ca


### PR DESCRIPTION
## Problem

The PRO `MicroVMGatewayReconciler` creates cert-manager `Certificate` CRs in workload namespaces (e.g. `e2e-session`). The `issuerRef` currently points to `kind: Issuer` named `kube-microvm-operator-ca`, which only exists in `kube-microvm`. cert-manager cannot issue the certificate:

```
Referenced Issuer does not exist
```

This means the gateway TLS Secret is never created → gateway Deployment pods can't mount TLS → gateway never Ready → all PRO UAT gateway tests fail (RC-2 in `KubeMicroVM-PRO/docs/design/uat-failure-analysis-rc2.md`).

## Fix

Adds `ClusterIssuer/kube-microvm-operator-ca` backed by the same CA Secret as the existing namespace-scoped Issuer. Gateway reconcilers in any namespace can now reference it as `kind: ClusterIssuer`.

Also included in the `helm-templates` zip artifact so PRO can access it.

## Future: per-namespace Issuer (opt-in)

Per-namespace Issuer for tenant isolation is tracked as a PRO roadmap item. Depends on RC-1 (CA Secret replication, already fixed in #94).

## Testing
- 90 tests pass
- `cluster-issuer.yaml` present in generated chart and `helm-templates.zip`